### PR TITLE
Categorize commands through MIO command API

### DIFF
--- a/Sources/D2Commands/CommandCategory.swift
+++ b/Sources/D2Commands/CommandCategory.swift
@@ -1,3 +1,7 @@
+import Utils
+
+fileprivate let emojiPattern = try! Regex(from: ":[^:]:")
+
 public enum CommandCategory: String, CaseIterable, CustomStringConvertible, Equatable {
     case administration
     case bf
@@ -53,5 +57,8 @@ public enum CommandCategory: String, CaseIterable, CustomStringConvertible, Equa
             case .videogame: return ":evergreen_tree: Video games"
             case .web: return ":globe_with_meridians: Web browsing"
         }
+    }
+    public var plainDescription: String {
+        emojiPattern.replace(in: description, with: "").trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Sources/D2Commands/administration/LogsCommand.swift
+++ b/Sources/D2Commands/administration/LogsCommand.swift
@@ -7,6 +7,7 @@ public class LogsCommand: StringCommand {
         category: .administration,
         shortDescription: "Fetches the logs",
         longDescription: "Outputs the most recently logged lines",
+        presented: true,
         requiredPermissionLevel: .admin
     )
     private let defaultLineCount: Int

--- a/Sources/D2Commands/bf/BFCommand.swift
+++ b/Sources/D2Commands/bf/BFCommand.swift
@@ -11,6 +11,7 @@ public class BFCommand: StringCommand {
         category: .bf,
         shortDescription: "Interprets BF code",
         longDescription: "Asynchronously invokes a Brainf&*k interpreter",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     private let maxExecutionSeconds: Int

--- a/Sources/D2Commands/bf/BFEncodeCommand.swift
+++ b/Sources/D2Commands/bf/BFEncodeCommand.swift
@@ -7,6 +7,7 @@ public class BFEncodeCommand: StringCommand {
         category: .bf,
         shortDescription: "Encodes strings to BF code",
         longDescription: "Encodes a string in BF code such that the string is located beginning at the zeroth cell",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     private let maxStringLength: Int

--- a/Sources/D2Commands/bf/BFInterpretCommand.swift
+++ b/Sources/D2Commands/bf/BFInterpretCommand.swift
@@ -6,7 +6,7 @@ import Dispatch
 
 fileprivate let log = Logger(label: "D2Commands.BFCommand")
 
-public class BFCommand: StringCommand {
+public class BFInterpretCommand: StringCommand {
     public let info = CommandInfo(
         category: .bf,
         shortDescription: "Interprets BF code",

--- a/Sources/D2Commands/bf/BFToCCommand.swift
+++ b/Sources/D2Commands/bf/BFToCCommand.swift
@@ -7,6 +7,7 @@ public class BFToCCommand: StringCommand {
         category: .bf,
         shortDescription: "Transpiles a BF program into C code",
         longDescription: "Outputs a C program whose functionality is equivalent to the given BF program",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .code

--- a/Sources/D2Commands/cau/mdb/MDBCommand.swift
+++ b/Sources/D2Commands/cau/mdb/MDBCommand.swift
@@ -11,6 +11,7 @@ public class MDBCommand: StringCommand {
         category: .cau,
         shortDescription: "Queries the MDB",
         longDescription: "Queries the Computer Science module database from the CAU",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/cau/univis/CampusCommand.swift
+++ b/Sources/D2Commands/cau/univis/CampusCommand.swift
@@ -17,6 +17,7 @@ public class CampusCommand: StringCommand {
         category: .cau,
         shortDescription: "Locates rooms on the CAU campus",
         longDescription: "Looks up room abbreviations (such as 'LMS4') in this UnivIS and outputs the address together with a static street map",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     let geocoder = MapQuestGeocoder()

--- a/Sources/D2Commands/cau/univis/UnivISCommand.swift
+++ b/Sources/D2Commands/cau/univis/UnivISCommand.swift
@@ -26,6 +26,7 @@ public class UnivISCommand: StringCommand {
         category: .cau,
         shortDescription: "Queries the UnivIS",
         longDescription: "Queries the lecture database 'UnivIS' from the CAU",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     let maxResponseEntries: Int

--- a/Sources/D2Commands/coding/CaesarCipherCommand.swift
+++ b/Sources/D2Commands/coding/CaesarCipherCommand.swift
@@ -12,6 +12,7 @@ public class CaesarCipherCommand: StringCommand {
         shortDescription: "Applies a caesar cipher",
         longDescription: "Substitutes each letter in the input by the same letter shifted by n places in the alphabet",
         helpText: "Syntax: [offset] [message]",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .text

--- a/Sources/D2Commands/coding/MorseDecoderCommand.swift
+++ b/Sources/D2Commands/coding/MorseDecoderCommand.swift
@@ -2,6 +2,7 @@ public class MorseDecoderCommand: StringCommand {
     public let info = CommandInfo(
         category: .coding,
         shortDescription: "Morse-decodes a string",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .text

--- a/Sources/D2Commands/coding/MorseEncoderCommand.swift
+++ b/Sources/D2Commands/coding/MorseEncoderCommand.swift
@@ -2,6 +2,7 @@ public class MorseEncoderCommand: StringCommand {
     public let info = CommandInfo(
         category: .coding,
         shortDescription: "Morse-encodes a string",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .text

--- a/Sources/D2Commands/dictionary/DBLPCommand.swift
+++ b/Sources/D2Commands/dictionary/DBLPCommand.swift
@@ -8,6 +8,7 @@ public class DBLPCommand: StringCommand {
         category: .dictionary,
         shortDescription: "Queries the DBLP database",
         longDescription: "Queries the Digital Bibliography & Library Project, a computer science bibliography database",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/dictionary/IMDBCommand.swift
+++ b/Sources/D2Commands/dictionary/IMDBCommand.swift
@@ -5,6 +5,7 @@ public class IMDBCommand: StringCommand {
     public let info = CommandInfo(
         category: .dictionary,
         shortDescription: "Searches the IMDB for movies and shows",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/dictionary/ThesaurizeCommand.swift
+++ b/Sources/D2Commands/dictionary/ThesaurizeCommand.swift
@@ -7,6 +7,7 @@ public class ThesaurizeCommand: StringCommand {
     public let info = CommandInfo(
         category: .dictionary,
         shortDescription: "Replaces text with synonyms",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/dictionary/ThesaurusCommand.swift
+++ b/Sources/D2Commands/dictionary/ThesaurusCommand.swift
@@ -6,6 +6,7 @@ public class ThesaurusCommand: StringCommand {
     public let info = CommandInfo(
         category: .dictionary,
         shortDescription: "Looks up a word on OpenThesaurus",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/dictionary/UniversitiesCommand.swift
+++ b/Sources/D2Commands/dictionary/UniversitiesCommand.swift
@@ -5,6 +5,7 @@ public class UniversitiesCommand: StringCommand {
     public let info = CommandInfo(
         category: .dictionary,
         shortDescription: "Searches for universities with a name worldwidely",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/emoji/EmojiCommand.swift
+++ b/Sources/D2Commands/emoji/EmojiCommand.swift
@@ -4,6 +4,7 @@ public class EmojiCommand: StringCommand {
     public let info = CommandInfo(
         category: .emoji,
         shortDescription: "Outputs a custom emoji by name",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/emoji/EmojiUsageCommand.swift
+++ b/Sources/D2Commands/emoji/EmojiUsageCommand.swift
@@ -6,6 +6,7 @@ public class EmojiUsageCommand: StringCommand {
     public let info = CommandInfo(
         category: .emoji,
         shortDescription: "Lists the most used emojis on the guild",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .embed

--- a/Sources/D2Commands/emoji/EmojisCommand.swift
+++ b/Sources/D2Commands/emoji/EmojisCommand.swift
@@ -5,6 +5,7 @@ public class EmojisCommand: StringCommand {
     public let info = CommandInfo(
         category: .emoji,
         shortDescription: "Fetches/searches the current guild's custom emojis",
+        presented: true,
         requiredPermissionLevel: .basic,
         platformAvailability: ["Discord"]
     )

--- a/Sources/D2Commands/feed/FeedCommand.swift
+++ b/Sources/D2Commands/feed/FeedCommand.swift
@@ -12,6 +12,7 @@ public class FeedCommand<P>: VoidCommand where P: FeedPresenter {
         info = CommandInfo(
             category: .feed,
             shortDescription: description,
+            presented: true,
             requiredPermissionLevel: .basic
         )
         self.url = URL(string: url)!

--- a/Sources/D2Commands/food/CocktailCommand.swift
+++ b/Sources/D2Commands/food/CocktailCommand.swift
@@ -8,6 +8,7 @@ public class CocktailCommand: StringCommand {
         category: .food,
         shortDescription: "Searches for a cocktail recipe",
         helpText: "Syntax: [search term]",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/forum/StackOverflowCommand.swift
+++ b/Sources/D2Commands/forum/StackOverflowCommand.swift
@@ -12,6 +12,7 @@ public class StackOverflowCommand: StringCommand {
         category: .forum,
         shortDescription: "Queries Stack Overflow",
         longDescription: "Searches Stack Overflow using the given input",
+        presented: true,
         requiredPermissionLevel: .vip
     )
 

--- a/Sources/D2Commands/fun/ChuckNorrisJokeCommand.swift
+++ b/Sources/D2Commands/fun/ChuckNorrisJokeCommand.swift
@@ -5,6 +5,7 @@ public class ChuckNorrisJokeCommand: StringCommand {
         category: .fun,
         shortDescription: "Outputs a random chuck norris joke",
         helpText: "Syntax: [first name]? [last name]?",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .text

--- a/Sources/D2Commands/fun/CookieCommand.swift
+++ b/Sources/D2Commands/fun/CookieCommand.swift
@@ -6,6 +6,7 @@ public class CookieCommand: Command {
     public let info = CommandInfo(
         category: .misc,
         shortDescription: "Gives someone a cookie",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let inputValueType: RichValueType = .mentions

--- a/Sources/D2Commands/fun/IAmBoredCommand.swift
+++ b/Sources/D2Commands/fun/IAmBoredCommand.swift
@@ -4,6 +4,7 @@ public class IAmBoredCommand: VoidCommand {
     public let info = CommandInfo(
         category: .fun,
         shortDescription: "Suggests something to do if you are bored!",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     private let verbs: [String]

--- a/Sources/D2Commands/fun/Magic8BallCommand.swift
+++ b/Sources/D2Commands/fun/Magic8BallCommand.swift
@@ -4,6 +4,7 @@ public class Magic8BallCommand: StringCommand {
     public let info = CommandInfo(
         category: .fun,
         shortDescription: "Answers a yes/no question",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .text

--- a/Sources/D2Commands/fun/PickupLineCommand.swift
+++ b/Sources/D2Commands/fun/PickupLineCommand.swift
@@ -4,6 +4,7 @@ public class PickupLineCommand: StringCommand {
     public let info = CommandInfo(
         category: .fun,
         shortDescription: "Outputs a random pickup line",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/functiological/HaskellCommand.swift
+++ b/Sources/D2Commands/functiological/HaskellCommand.swift
@@ -9,6 +9,7 @@ public class HaskellCommand: StringCommand {
         category: .functiological,
         shortDescription: "Evaluates a Haskell expression",
         longDescription: "Computes the result of a (pure) Haskell expression using Mueval",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .code

--- a/Sources/D2Commands/functiological/HoogleCommand.swift
+++ b/Sources/D2Commands/functiological/HoogleCommand.swift
@@ -17,6 +17,7 @@ public class HoogleCommand: StringCommand {
         category: .functiological,
         shortDescription: "Hoogles a type signature",
         longDescription: "Searches for a function matching a type signature using the Hoogle search engine",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .embed

--- a/Sources/D2Commands/functiological/PointfreeCommand.swift
+++ b/Sources/D2Commands/functiological/PointfreeCommand.swift
@@ -9,6 +9,7 @@ public class PointfreeCommand: StringCommand {
         category: .functiological,
         shortDescription: "Pointfree notation converter",
         longDescription: "Converts a Haskell expression into pointfree notation",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .code

--- a/Sources/D2Commands/functiological/PointfulCommand.swift
+++ b/Sources/D2Commands/functiological/PointfulCommand.swift
@@ -9,6 +9,7 @@ public class PointfulCommand: StringCommand {
         category: .functiological,
         shortDescription: "Pointful notation converter",
         longDescription: "Converts a Haskell expression into pointful notation",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .code

--- a/Sources/D2Commands/game/GameCommand.swift
+++ b/Sources/D2Commands/game/GameCommand.swift
@@ -13,6 +13,7 @@ fileprivate let actionMessageRegex = try! Regex(from: "^(\\S+)(?:\\s+(.+))?")
 public class GameCommand<G: Game>: Command {
     public private(set) var info = CommandInfo(
         category: .game,
+        presented: true,
         requiredPermissionLevel: .basic,
         subscribesToNextMessages: true,
         userOnly: false

--- a/Sources/D2Commands/git/ChangeLogCommand.swift
+++ b/Sources/D2Commands/git/ChangeLogCommand.swift
@@ -6,6 +6,7 @@ public class ChangeLogCommand: StringCommand {
     public let info = CommandInfo(
         category: .git,
         shortDescription: "Fetches the latest commits to D2's repo",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/git/GitLabCommand.swift
+++ b/Sources/D2Commands/git/GitLabCommand.swift
@@ -12,6 +12,7 @@ public class GitLabCommand: StringCommand {
         category: .git,
         shortDescription: "Queries a GitLab server",
         longDescription: "Fetches CI/CD pipeline information and more from a GitLab server",
+        presented: true,
         requiredPermissionLevel: .vip
     )
     @AutoSerializing(filePath: "local/gitLabConfig.json") private var gitLabConfig: GitLabConfiguration = .init()

--- a/Sources/D2Commands/imaging/AvatarCommand.swift
+++ b/Sources/D2Commands/imaging/AvatarCommand.swift
@@ -14,6 +14,7 @@ public class AvatarCommand: Command {
         shortDescription: "Fetches the avatar of a user",
         longDescription: "Fetches the user's profile picture and outputs it in PNG form",
         helpText: "Syntax: [@user]",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let inputValueType: RichValueType = .mentions

--- a/Sources/D2Commands/imaging/GraphVizCommand.swift
+++ b/Sources/D2Commands/imaging/GraphVizCommand.swift
@@ -5,6 +5,7 @@ import Graphics
 public class GraphVizCommand: StringCommand {
     public private(set) var info = CommandInfo(
         category: .imaging,
+        presented: true,
         requiredPermissionLevel: .basic
     )
     private let layout: LayoutAlgorithm

--- a/Sources/D2Commands/imaging/QRCodeCommand.swift
+++ b/Sources/D2Commands/imaging/QRCodeCommand.swift
@@ -3,7 +3,7 @@ import Graphics
 import Utils
 import QRCodeGenerator
 
-public class QRCommand: StringCommand {
+public class QRCodeCommand: StringCommand {
     public let info = CommandInfo(
         category: .imaging,
         shortDescription: "Generates a QR code",

--- a/Sources/D2Commands/imaging/QRCommand.swift
+++ b/Sources/D2Commands/imaging/QRCommand.swift
@@ -8,6 +8,7 @@ public class QRCommand: StringCommand {
         category: .imaging,
         shortDescription: "Generates a QR code",
         longDescription: "Generates a QR code from given text",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/meta/CommandCountCommand.swift
+++ b/Sources/D2Commands/meta/CommandCountCommand.swift
@@ -4,6 +4,7 @@ public class CommandCountCommand: VoidCommand {
     public let info = CommandInfo(
         category: .meta,
         shortDescription: "Counts the number of available commands",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/meta/CommandOfTheDayCommand.swift
+++ b/Sources/D2Commands/meta/CommandOfTheDayCommand.swift
@@ -5,6 +5,7 @@ public class CommandOfTheDayCommand: VoidCommand {
     public let info = CommandInfo(
         category: .meta,
         shortDescription: "Showcases a new command, every day",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     private let commandPrefix: String

--- a/Sources/D2Commands/meta/HelpCommand.swift
+++ b/Sources/D2Commands/meta/HelpCommand.swift
@@ -96,7 +96,7 @@ public class HelpCommand: StringCommand {
 
                 \(command.info.helpText ?? "")
                 """.trimmingCharacters(in: .whitespaces),
-            footer: Embed.Footer(text: "\(command.info.category)")
+            footer: Embed.Footer(text: command.info.category.plainDescription)
         )
     }
 }

--- a/Sources/D2Commands/meta/IOPlatformCommand.swift
+++ b/Sources/D2Commands/meta/IOPlatformCommand.swift
@@ -2,6 +2,7 @@ public class IOPlatformCommand: VoidCommand {
     public let info = CommandInfo(
         category: .meta,
         shortDescription: "Outputs the IO platform",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/meta/IssueReportCommand.swift
+++ b/Sources/D2Commands/meta/IssueReportCommand.swift
@@ -5,6 +5,7 @@ public class IssueReportCommand: StringCommand {
     public let info = CommandInfo(
         category: .meta,
         shortDescription: "Provides a link to the bug report form",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/meta/SearchCommand.swift
+++ b/Sources/D2Commands/meta/SearchCommand.swift
@@ -6,6 +6,7 @@ public class SearchCommand: StringCommand {
     public let info = CommandInfo(
         category: .meta,
         shortDescription: "Searches for available commands",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .embed

--- a/Sources/D2Commands/misc/CoinFlipCommand.swift
+++ b/Sources/D2Commands/misc/CoinFlipCommand.swift
@@ -2,6 +2,7 @@ public class CoinFlipCommand: StringCommand {
     public let info = CommandInfo(
         category: .misc,
         shortDescription: "Flips a coin",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/misc/GeocodeCommand.swift
+++ b/Sources/D2Commands/misc/GeocodeCommand.swift
@@ -5,6 +5,7 @@ public class GeocodeCommand: StringCommand {
     public let info = CommandInfo(
         category: .misc,
         shortDescription: "Finds the geographical coordinates of an address",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .geoCoordinates

--- a/Sources/D2Commands/misc/MarkovCommand.swift
+++ b/Sources/D2Commands/misc/MarkovCommand.swift
@@ -13,6 +13,7 @@ public class MarkovCommand: StringCommand {
         shortDescription: "Generates a natural language response using a Markov chain",
         longDescription: "Uses a Markov chain with data from the current channel to generate a human-like response",
         helpText: "Syntax: markov [--all]? [--withping]?",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     private let messageDB: MessageDatabase

--- a/Sources/D2Commands/misc/TimerCommand.swift
+++ b/Sources/D2Commands/misc/TimerCommand.swift
@@ -33,6 +33,7 @@ public class TimerCommand: StringCommand {
     public private(set) var info = CommandInfo(
         category: .misc,
         shortDescription: "Pings a group of users after the timer elapses",
+        presented: true,
         requiredPermissionLevel: .vip
     )
     private var subcommands: [String: (String, CommandOutput, CommandContext) -> Void] = [:]

--- a/Sources/D2Commands/misc/TranslateCommand.swift
+++ b/Sources/D2Commands/misc/TranslateCommand.swift
@@ -9,6 +9,7 @@ public class TranslateCommand: StringCommand {
         category: .misc,
         shortDescription: "Translates text into another language",
         helpText: "Syntax: [target language, e.g. en] [text]",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/misc/WeatherCommand.swift
+++ b/Sources/D2Commands/misc/WeatherCommand.swift
@@ -6,6 +6,7 @@ public class WeatherCommand: StringCommand {
     public let info = CommandInfo(
         category: .misc,
         shortDescription: "Fetches the weather for a city",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/music/GuessKeyCommand.swift
+++ b/Sources/D2Commands/music/GuessKeyCommand.swift
@@ -5,6 +5,7 @@ public class FindKeyCommand: StringCommand {
         category: .music,
         shortDescription: "Determines a list of possible major/minor keys given a list of notes",
         helpText: "Syntax: [note]...",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/music/TransposeChordsCommand.swift
+++ b/Sources/D2Commands/music/TransposeChordsCommand.swift
@@ -7,6 +7,7 @@ public class TransposeChordsCommand: StringCommand {
         category: .music,
         shortDescription: "Transposes a sequence of notes/chords",
         helpText: "Syntax: [number of half steps] [note]...",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/output/RichValueType.swift
+++ b/Sources/D2Commands/output/RichValueType.swift
@@ -1,4 +1,4 @@
-public enum RichValueType: CustomStringConvertible {
+public enum RichValueType: CustomStringConvertible, Hashable {
     case none
     case text
     case image

--- a/Sources/D2Commands/quote/DesignQuoteCommand.swift
+++ b/Sources/D2Commands/quote/DesignQuoteCommand.swift
@@ -9,6 +9,7 @@ public class DesignQuoteCommand: StringCommand {
     public let info = CommandInfo(
         category: .quote,
         shortDescription: "Fetches a random quote about design",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .embed

--- a/Sources/D2Commands/videogame/FTBModpacksCommand.swift
+++ b/Sources/D2Commands/videogame/FTBModpacksCommand.swift
@@ -8,6 +8,7 @@ public class FTBModpacksCommand: StringCommand {
         category: .videogame,
         shortDescription: "Fetches a list of FTB modpacks",
         longDescription: "Fetches a list of recent Feed The Beast modpacks with descriptions and download links",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .embed

--- a/Sources/D2Commands/videogame/GModServerPingCommand.swift
+++ b/Sources/D2Commands/videogame/GModServerPingCommand.swift
@@ -7,6 +7,7 @@ public class GModServerPingCommand: StringCommand {
         category: .videogame,
         shortDescription: "Pings a Garry's mod (Source) server",
         helpText: "Syntax: [address]:[port]?",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Commands/videogame/MinecraftDynmapCommand.swift
+++ b/Sources/D2Commands/videogame/MinecraftDynmapCommand.swift
@@ -11,6 +11,7 @@ public class MinecraftDynmapCommand: StringCommand {
         shortDescription: "Queries the dynmap of a Minecraft server",
         longDescription: "Fetches world information from a Minecraft server running the 'dynmap' plugin",
         helpText: "Syntax: [server host] [player name]?",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .embed

--- a/Sources/D2Commands/videogame/MinecraftModSearchCommand.swift
+++ b/Sources/D2Commands/videogame/MinecraftModSearchCommand.swift
@@ -9,6 +9,7 @@ public class MinecraftModSearchCommand: StringCommand {
         shortDescription: "Finds a Minecraft mod online",
         longDescription: "Finds a Minecraft mod on CurseForge",
         helpText: "Syntax: [mod name]",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .embed

--- a/Sources/D2Commands/videogame/MinecraftServerModsCommand.swift
+++ b/Sources/D2Commands/videogame/MinecraftServerModsCommand.swift
@@ -7,6 +7,7 @@ public class MinecraftServerModsCommand: StringCommand {
         category: .videogame,
         shortDescription: "Fetches a Minecraft server's modlist",
         longDescription: "Fetches a list of mods used by a given server",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .embed

--- a/Sources/D2Commands/videogame/MinecraftServerPingCommand.swift
+++ b/Sources/D2Commands/videogame/MinecraftServerPingCommand.swift
@@ -11,6 +11,7 @@ public class MinecraftServerPingCommand: StringCommand {
         category: .videogame,
         shortDescription: "Pings a Minecraft server",
         longDescription: "Fetches the Message of the Day (MOTD) and the current player list of a Minecraft server",
+        presented: true,
         requiredPermissionLevel: .basic
     )
     public let outputValueType: RichValueType = .embed

--- a/Sources/D2Commands/videogame/MinecraftWikiCommand.swift
+++ b/Sources/D2Commands/videogame/MinecraftWikiCommand.swift
@@ -8,6 +8,7 @@ public class MinecraftWikiCommand: StringCommand {
         category: .videogame,
         shortDescription: "Queries Minecraft Wiki",
         longDescription: "Queries Minecraft Wiki for an article",
+        presented: true,
         requiredPermissionLevel: .basic
     )
 

--- a/Sources/D2Handlers/D2Delegate.swift
+++ b/Sources/D2Handlers/D2Delegate.swift
@@ -534,9 +534,10 @@ public class D2Delegate: MessageDelegate {
         guard
             useMIOCommands,
             interaction.type == .mioCommand,
-            let data = interaction.data else { return }
+            let data = interaction.data,
+            let invocation = data.options.first else { return }
 
-        let content = data.options.compactMap { $0.value as? String }.joined(separator: " ")
+        let content = invocation.options.compactMap { $0.value as? String }.joined(separator: " ")
         let input = RichValue.text(content)
         let context = CommandContext(
             client: client,
@@ -557,8 +558,8 @@ public class D2Delegate: MessageDelegate {
             output.append(errorText: "The interaction must have an author!")
             return
         }
-        guard let name = data.options.first?.name, let command = registry[name] else {
-            output.append(errorText: "Unknown command in category `\(data.name)`")
+        guard let command = registry[invocation.name] else {
+            output.append(errorText: "Unknown command name `\(invocation.name)`")
             return
         }
         guard permissionManager.user(author, hasPermission: command.info.requiredPermissionLevel, usingSimulated: command.info.usesSimulatedPermissionLevel) else {

--- a/Sources/D2Handlers/D2Delegate.swift
+++ b/Sources/D2Handlers/D2Delegate.swift
@@ -228,7 +228,7 @@ public class D2Delegate: MessageDelegate {
         registry["avatargif"] = AvatarCommand(preferredExtension: "gif")
         registry["avatarurl"] = AvatarUrlCommand()
         registry["ocr"] = OCRCommand()
-        registry["qr"] = QRCommand()
+        registry["qrcode", aka: ["qr"]] = QRCodeCommand()
         registry["latex"] = LatexCommand()
         registry["autolatex"] = AutoLatexCommand()
         registry["enterprisify"] = EnterprisifyCommand()
@@ -416,7 +416,7 @@ public class D2Delegate: MessageDelegate {
             var registeredCount = 0
             let groupedCommands = Dictionary(grouping: registry.commandsWithAliases(), by: \.command.info.category)
 
-            for (category, cmds) in groupedCommands {
+            for (category, cmds) in groupedCommands where category.rawValue.count >= 3 {
                 let shownCmds = cmds
                     .sorted(by: ascendingComparator { $0.command.info.requiredPermissionLevel.rawValue })
                     .filter { $0.command.info.presented }

--- a/Sources/D2Handlers/D2Delegate.swift
+++ b/Sources/D2Handlers/D2Delegate.swift
@@ -557,8 +557,8 @@ public class D2Delegate: MessageDelegate {
             output.append(errorText: "The interaction must have an author!")
             return
         }
-        guard let command = registry[data.name] else {
-            output.append(errorText: "Unknown command name `\(data.name)`")
+        guard let name = data.options.first?.name, let command = registry[name] else {
+            output.append(errorText: "Unknown command in category `\(data.name)`")
             return
         }
         guard permissionManager.user(author, hasPermission: command.info.requiredPermissionLevel, usingSimulated: command.info.usesSimulatedPermissionLevel) else {

--- a/Sources/D2Handlers/D2Delegate.swift
+++ b/Sources/D2Handlers/D2Delegate.swift
@@ -417,12 +417,16 @@ public class D2Delegate: MessageDelegate {
             let groupedCommands = Dictionary(grouping: registry.commandsWithAliases(), by: \.command.info.category)
 
             for (category, cmds) in groupedCommands {
-                let shownCmds = cmds.prefix(50) // TODO: Use presented
+                let shownCmds = cmds
+                    .sorted(by: ascendingComparator { $0.command.info.requiredPermissionLevel.rawValue })
+                    .filter { $0.command.info.presented }
+                    .prefix(10)
+
                 let options = shownCmds
                     .map {
                         MIOCommand.Option(
                             type: .subCommand,
-                            name: $0.name,
+                            name: ([$0.name] + $0.aliases).first { (3..<32).contains($0.count) } ?? $0.name.truncated(to: 28, appending: "..."),
                             description: $0.command.info.shortDescription,
                             options: $0.command.inputValueType == .text
                                 ? [.init(

--- a/Sources/D2Handlers/D2Delegate.swift
+++ b/Sources/D2Handlers/D2Delegate.swift
@@ -442,14 +442,14 @@ public class D2Delegate: MessageDelegate {
                     client.createMIOCommand(
                         on: guildId,
                         name: category.rawValue,
-                        description: category.description,
+                        description: category.plainDescription,
                         options: options
                     )
                 } else {
                     // Register MIO commands globally
                     client.createMIOCommand(
                         name: category.rawValue,
-                        description: category.description,
+                        description: category.plainDescription,
                         options: options
                     )
                 }

--- a/Sources/D2Handlers/D2Delegate.swift
+++ b/Sources/D2Handlers/D2Delegate.swift
@@ -78,7 +78,7 @@ public class D2Delegate: MessageDelegate {
         registry["ping"] = PingCommand()
         registry["beep"] = PingCommand(response: "Bop")
         registry["vertical"] = VerticalCommand()
-        registry["bf"] = BFCommand()
+        registry["bfinterpret", aka: ["bf"]] = BFInterpretCommand()
         registry["bfencode"] = BFEncodeCommand()
         registry["bftoc"] = BFToCCommand()
         registry["base64encode", aka: ["base64"]] = Base64EncoderCommand()

--- a/Sources/D2MessageIO/CombinedMessageClient.swift
+++ b/Sources/D2MessageIO/CombinedMessageClient.swift
@@ -161,7 +161,7 @@ public class CombinedMessageClient: MessageClient {
     }
 
     public func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) -> Promise<Bool, Error> {
-        withClient(of: guildId) { $0.deleteMIOCommand(commandId) } ?? Promise(.failure(MessageClientError.noMIOCommandClient))
+        withClient(of: guildId) { $0.deleteMIOCommand(commandId, on: guildId) } ?? Promise(.failure(MessageClientError.noMIOCommandClient))
     }
 
     public func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, Error> {

--- a/Sources/D2MessageIO/MessageClient.swift
+++ b/Sources/D2MessageIO/MessageClient.swift
@@ -140,21 +140,21 @@ public extension MessageClient {
     @discardableResult
     func deleteMIOCommands() -> Promise<Void, Error> {
         // Note how this only deletes *global* MIO commands
-        getMIOCommands().map {
-            for cmd in $0 {
+        getMIOCommands().then {
+            all(promises: $0.map { cmd -> Promise<Bool, Error> in
                 log.info("Deleting MIO command with ID \(cmd.id)")
-                deleteMIOCommand(cmd.id)
-            }
+                return deleteMIOCommand(cmd.id)
+            }).void()
         }
     }
 
     @discardableResult
     func deleteMIOCommands(on guildId: GuildID) -> Promise<Void, Error> {
-        getMIOCommands(on: guildId).map {
-            for cmd in $0 {
+        getMIOCommands(on: guildId).then {
+            all(promises: $0.map { cmd -> Promise<Bool, Error> in
                 log.info("Deleting MIO command with ID \(cmd.id) from guild \(guildId)")
-                deleteMIOCommand(cmd.id, on: guildId)
-            }
+                return deleteMIOCommand(cmd.id, on: guildId)
+            }).void()
         }
     }
 }

--- a/Sources/D2MessageIO/MessageClient.swift
+++ b/Sources/D2MessageIO/MessageClient.swift
@@ -1,5 +1,8 @@
 import Foundation
+import Logging
 import Utils
+
+fileprivate let log = Logger(label: "D2MessageIO.MessageClient")
 
 public protocol MessageClient {
     var name: String { get }
@@ -139,6 +142,7 @@ public extension MessageClient {
         // Note how this only deletes *global* MIO commands
         getMIOCommands().map {
             for cmd in $0 {
+                log.info("Deleting MIO command with ID \(cmd.id)")
                 deleteMIOCommand(cmd.id)
             }
         }
@@ -148,6 +152,7 @@ public extension MessageClient {
     func deleteMIOCommands(on guildId: GuildID) -> Promise<Void, Error> {
         getMIOCommands(on: guildId).map {
             for cmd in $0 {
+                log.info("Deleting MIO command with ID \(cmd.id) from guild \(guildId)")
                 deleteMIOCommand(cmd.id, on: guildId)
             }
         }

--- a/Sources/D2MessageIO/MessageClient.swift
+++ b/Sources/D2MessageIO/MessageClient.swift
@@ -133,4 +133,23 @@ public extension MessageClient {
     func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String) -> Promise<MIOCommand?, Error> {
         editMIOCommand(commandId, on: guildId, name: name, description: description, options: nil)
     }
+
+    @discardableResult
+    func deleteMIOCommands() -> Promise<Void, Error> {
+        // Note how this only deletes *global* MIO commands
+        getMIOCommands().map {
+            for cmd in $0 {
+                deleteMIOCommand(cmd.id)
+            }
+        }
+    }
+
+    @discardableResult
+    func deleteMIOCommands(on guildId: GuildID) -> Promise<Void, Error> {
+        getMIOCommands(on: guildId).map {
+            for cmd in $0 {
+                deleteMIOCommand(cmd.id, on: guildId)
+            }
+        }
+    }
 }

--- a/Sources/D2MessageIO/OverlayMessageClient.swift
+++ b/Sources/D2MessageIO/OverlayMessageClient.swift
@@ -129,7 +129,7 @@ public struct OverlayMessageClient: MessageClient {
     }
 
     public func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) -> Promise<Bool, Error> {
-        inner.deleteMIOCommand(commandId)
+        inner.deleteMIOCommand(commandId, on: guildId)
     }
 
     public func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, Error> {


### PR DESCRIPTION
Categorize the commands when exposing them through MIO (e.g. using Discord's slash commands as backend).