### PR TITLE
Dockerfile improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.dockerignore
+docker-compose.yml
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
 .git
+.github
+.vscode
 .dockerignore
+.editorconfig
+.gitignore
+.gitlab-ci.yml
 docker-compose.yml
 Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,16 +29,16 @@ RUN cabal update && cabal install mueval pointfree-1.1.1.6 pointful
 # Add Cabal to PATH
 ENV PATH /.cabal/bin:/root/.cabal/bin:$PATH
 
-# Copy application
 WORKDIR /opt/d2
-COPY . .
 
 # Install Node dependencies
+COPY Node Node
 WORKDIR /opt/d2/Node
 RUN ./install-all
 
 # Build
 WORKDIR /opt/d2
+COPY . .
 RUN swift build -c release
 
 CMD ["./.build/release/D2"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,14 +46,16 @@ RUN cabal update && cabal install mueval pointfree-1.1.1.6 pointful
 # Add Cabal to PATH
 ENV PATH /.cabal/bin:/root/.cabal/bin:$PATH
 
-WORKDIR /opt/d2
-
 # Install Node dependencies
-COPY Node Node
+COPY Node /opt/d2/Node
 WORKDIR /opt/d2/Node
 RUN ./install-all
 
 WORKDIR /opt/d2/
+
+# Add resources
+COPY Resources Resources
+
 COPY --from=builder "/opt/d2/.build/release/D2" .
 
 CMD ["./D2"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ RUN add-apt-repository -y ppa:alex-p/tesseract-ocr && apt-get update && apt-get 
     libsqlite3-dev \
     libgraphviz-dev \
     libtesseract-dev \
-    libleptonica-dev
+    libleptonica-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Build
 WORKDIR /opt/d2
@@ -20,12 +21,9 @@ RUN swift build -c release
 
 FROM swift:5.4-slim as runner
 
-# Install Curl and node package repository
-RUN apt-get update && apt-get install -y curl
+# Install Curl, add-apt-repository and node package repository
+RUN apt-get update && apt-get install -y curl software-properties-common && rm -rf /var/lib/apt/lists/*
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash -
-
-# Install add-apt-repository
-RUN apt-get update && apt-get install -y software-properties-common
 
 # Install native dependencies
 RUN add-apt-repository -y ppa:alex-p/tesseract-ocr && apt-get update && apt-get install -y \
@@ -39,7 +37,8 @@ RUN add-apt-repository -y ppa:alex-p/tesseract-ocr && apt-get update && apt-get 
     maxima \
     cabal-install \
     graphviz \
-    nodejs
+    nodejs \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN cabal update && cabal install happy
 RUN cabal update && cabal install mueval pointfree-1.1.1.6 pointful


### PR DESCRIPTION
This PR refactors the Dockerfile to use multi-stage builds, with the final image only including the runtime libraries.

This reduces the final docker image size by 60% from 5.7GB to 2.3GB.

By restructuring the Dockerfile and adding a `.dockerignore` file, layer caching is optimized and build times reduced.
When Docker is being used for development, only the swift build step has to be re-run when changes to the source code have been made.