### PR TITLE
Reenable macOS 12 CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: ['ubuntu-latest']
-        # TODO: Reenable once macOS 12 becomes available
-        # os: ['ubuntu-latest', 'macos-12']
+        os: ['ubuntu-latest', 'macos-12']
         swift: ['5.6']
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The macOS 12 CI recently became generally available: https://github.blog/changelog/2022-06-13-github-actions-macos-12-for-github-hosted-runners-is-now-generally-available/