### PR TITLE
Fix PersistentVolumeClaim

### DIFF
--- a/Helm/d2/templates/persistent-volume-claim.yaml
+++ b/Helm/d2/templates/persistent-volume-claim.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   storageClassName: {{ .Values.storageClaim.storageClassName | quote }}
   accessModes:
-  - ReadWriteMany
+  - ReadWriteOnce
   resources:
     requests:
       storage: {{ .Values.storageClaim.size | quote }}


### PR DESCRIPTION
Adjust `accessMode` to be `ReadWriteOnce` instead of `ReadWriteMany`. By default, K3s comes with a **local-path** storage provision option. This option binds persistent volumes to the node they are located on. Therefore, it does not support ReadWriteMany, since other nodes are not able to access the local storage of another node.