### PR TITLE
feat(ci): tag image with current commit hash

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -28,5 +28,7 @@ jobs:
         context: .
         platforms: linux/amd64,linux/arm64/v8
         push: ${{ github.ref == 'refs/heads/main' }}
-        tags: ghcr.io/fwcd/d2:latest
+        tags: |
+          ghcr.io/fwcd/d2:latest
+          ghcr.io/fwcd/d2:${{ github.sha }}
   


### PR DESCRIPTION
This PR aims to provide great functionality by utilising a brand new feature of git: _commit hashes_

Hashes are capable of uniquely identifying a commit, and, therefore, they are great to identify certain versions of docker images as well!