### PR TITLE
Refactor Message IO layer

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -166,8 +166,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/fwcd/swift-discord.git",
       "state" : {
-        "revision" : "b15e50ab0aa6e26b002c246503186371a4d3133f",
-        "version" : "10.1.2"
+        "revision" : "6ac860ee373724e65e6d62c26601fa8edf5aabda",
+        "version" : "10.1.3"
       }
     },
     {

--- a/Sources/D2/D2.swift
+++ b/Sources/D2/D2.swift
@@ -78,7 +78,7 @@ struct D2: ParsableCommand {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
         // Create platforms
-        var combinedClient: CombinedMessageClient! = CombinedMessageClient(mioCommandClientName: "Discord")
+        var combinedClient: CombinedMessageIOSink! = CombinedMessageIOSink(mioCommandClientName: "Discord")
         var platforms: [any Startable] = []
         var createdAnyPlatform = false
 

--- a/Sources/D2/D2.swift
+++ b/Sources/D2/D2.swift
@@ -78,7 +78,7 @@ struct D2: ParsableCommand {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
         // Create platforms
-        var combinedClient: CombinedSink! = CombinedSink(mioCommandClientName: "Discord")
+        var combinedSink: CombinedSink! = CombinedSink(mioCommandSinkName: "Discord")
         var platforms: [any Startable] = []
         var createdAnyPlatform = false
 
@@ -90,18 +90,18 @@ struct D2: ParsableCommand {
             mioCommandGuildId: config?.useMIOCommandsOnlyOnGuild,
             logBuffer: logBuffer,
             eventLoopGroup: eventLoopGroup,
-            client: combinedClient
+            sink: combinedSink
         )
 
         if let discordToken = tokens.discord {
             createdAnyPlatform = true
-            platforms.append(DiscordPlatform(with: handler, combinedClient: combinedClient, eventLoopGroup: eventLoopGroup, token: discordToken))
+            platforms.append(DiscordPlatform(with: handler, combinedSink: combinedSink, eventLoopGroup: eventLoopGroup, token: discordToken))
         }
 
         for irc in tokens.irc ?? [] {
             do {
                 createdAnyPlatform = true
-                platforms.append(try IRCPlatform(with: handler, combinedClient: combinedClient, eventLoopGroup: eventLoopGroup, token: irc))
+                platforms.append(try IRCPlatform(with: handler, combinedSink: combinedSink, eventLoopGroup: eventLoopGroup, token: irc))
             } catch {
                 log.warning("Could not create IRC platform: \(error)")
             }
@@ -118,7 +118,7 @@ struct D2: ParsableCommand {
             log.info("Shutting down...")
             platforms.removeAll()
             handler = nil
-            combinedClient = nil
+            combinedSink = nil
             try! eventLoopGroup.syncShutdownGracefully()
             Self.exit()
         }
@@ -127,7 +127,7 @@ struct D2: ParsableCommand {
         // Register channel log output if needed
         if let logChannel = config?.log?.channel {
             logOutput.registerAsync {
-                combinedClient.sendMessage($0, to: logChannel)
+                combinedSink.sendMessage($0, to: logChannel)
             }
         }
 

--- a/Sources/D2/D2.swift
+++ b/Sources/D2/D2.swift
@@ -82,7 +82,7 @@ struct D2: ParsableCommand {
         var platforms: [any Startable] = []
         var createdAnyPlatform = false
 
-        var handler: D2Delegate! = try D2Delegate(
+        var receiver: D2Receiver! = try D2Receiver(
             withPrefix: commandPrefix,
             hostInfo: hostInfo,
             initialPresence: actualInitialPresence,
@@ -95,13 +95,23 @@ struct D2: ParsableCommand {
 
         if let discordToken = tokens.discord {
             createdAnyPlatform = true
-            platforms.append(DiscordPlatform(with: handler, combinedSink: combinedSink, eventLoopGroup: eventLoopGroup, token: discordToken))
+            platforms.append(DiscordPlatform(
+                receiver: receiver,
+                combinedSink: combinedSink,
+                eventLoopGroup: eventLoopGroup,
+                token: discordToken
+            ))
         }
 
         for irc in tokens.irc ?? [] {
             do {
                 createdAnyPlatform = true
-                platforms.append(try IRCPlatform(with: handler, combinedSink: combinedSink, eventLoopGroup: eventLoopGroup, token: irc))
+                platforms.append(try IRCPlatform(
+                    receiver: receiver,
+                    combinedSink: combinedSink,
+                    eventLoopGroup: eventLoopGroup,
+                    token: irc
+                ))
             } catch {
                 log.warning("Could not create IRC platform: \(error)")
             }
@@ -117,7 +127,7 @@ struct D2: ParsableCommand {
         source.setEventHandler {
             log.info("Shutting down...")
             platforms.removeAll()
-            handler = nil
+            receiver = nil
             combinedSink = nil
             try! eventLoopGroup.syncShutdownGracefully()
             Self.exit()

--- a/Sources/D2/D2.swift
+++ b/Sources/D2/D2.swift
@@ -78,7 +78,7 @@ struct D2: ParsableCommand {
         let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
 
         // Create platforms
-        var combinedClient: CombinedMessageIOSink! = CombinedMessageIOSink(mioCommandClientName: "Discord")
+        var combinedClient: CombinedSink! = CombinedSink(mioCommandClientName: "Discord")
         var platforms: [any Startable] = []
         var createdAnyPlatform = false
 

--- a/Sources/D2Commands/CommandContext.swift
+++ b/Sources/D2Commands/CommandContext.swift
@@ -6,7 +6,7 @@ import NIO
 fileprivate let log = Logger(label: "D2Commands.CommandContext")
 
 public struct CommandContext {
-    public let client: (any MessageClient)?
+    public let client: (any MessageIOSink)?
     public let registry: CommandRegistry
     public let message: Message
     public let channel: InteractiveTextChannel?
@@ -25,7 +25,7 @@ public struct CommandContext {
     public var isSubscribed: Bool { (channel?.id).map { subscriptions.contains($0) } ?? false }
 
     public init(
-        client: (any MessageClient)?,
+        client: (any MessageIOSink)?,
         registry: CommandRegistry,
         message: Message,
         commandPrefix: String,

--- a/Sources/D2Commands/CommandContext.swift
+++ b/Sources/D2Commands/CommandContext.swift
@@ -6,7 +6,7 @@ import NIO
 fileprivate let log = Logger(label: "D2Commands.CommandContext")
 
 public struct CommandContext {
-    public let client: (any Sink)?
+    public let sink: (any Sink)?
     public let registry: CommandRegistry
     public let message: Message
     public let channel: InteractiveTextChannel?
@@ -20,12 +20,12 @@ public struct CommandContext {
     public var author: User? { message.author }
     public var timestamp: Date? { message.timestamp }
     public var guildMember: Guild.Member? { message.guildMember }
-    public var guild: Guild? { message.channelId.flatMap { client?.guildForChannel($0) } }
+    public var guild: Guild? { message.channelId.flatMap { sink?.guildForChannel($0) } }
 
     public var isSubscribed: Bool { (channel?.id).map { subscriptions.contains($0) } ?? false }
 
     public init(
-        client: (any Sink)?,
+        sink: (any Sink)?,
         registry: CommandRegistry,
         message: Message,
         commandPrefix: String,
@@ -33,7 +33,7 @@ public struct CommandContext {
         subscriptions: SubscriptionSet,
         eventLoopGroup: (any EventLoopGroup)? = nil
     ) {
-        self.client = client
+        self.sink = sink
         self.registry = registry
         self.message = message
         self.commandPrefix = commandPrefix
@@ -41,7 +41,7 @@ public struct CommandContext {
         self.subscriptions = subscriptions
         self.eventLoopGroup = eventLoopGroup
 
-        channel = client.flatMap { c in message.channelId.map { InteractiveTextChannel(id: $0, client: c) } }
+        channel = sink.flatMap { c in message.channelId.map { InteractiveTextChannel(id: $0, sink: c) } }
     }
 
     /// Subscribes to the current channel.

--- a/Sources/D2Commands/CommandContext.swift
+++ b/Sources/D2Commands/CommandContext.swift
@@ -6,7 +6,7 @@ import NIO
 fileprivate let log = Logger(label: "D2Commands.CommandContext")
 
 public struct CommandContext {
-    public let client: (any MessageIOSink)?
+    public let client: (any Sink)?
     public let registry: CommandRegistry
     public let message: Message
     public let channel: InteractiveTextChannel?
@@ -25,7 +25,7 @@ public struct CommandContext {
     public var isSubscribed: Bool { (channel?.id).map { subscriptions.contains($0) } ?? false }
 
     public init(
-        client: (any MessageIOSink)?,
+        client: (any Sink)?,
         registry: CommandRegistry,
         message: Message,
         commandPrefix: String,

--- a/Sources/D2Commands/administration/RemoveAllMIOCommandsCommand.swift
+++ b/Sources/D2Commands/administration/RemoveAllMIOCommandsCommand.swift
@@ -8,17 +8,17 @@ public class RemoveAllMIOCommandsCommand: VoidCommand {
     public init() {}
 
     public func invoke(output: any CommandOutput, context: CommandContext) {
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "No client present")
             return
         }
 
-        client.getMIOCommands().listen {
+        sink.getMIOCommands().listen {
             do {
                 let mioCommands = try $0.get()
 
                 for mioCommand in mioCommands {
-                    client.deleteMIOCommand(mioCommand.id)
+                    sink.deleteMIOCommand(mioCommand.id)
                 }
 
                 output.append("Deleted \(mioCommands.count) MIO commands")

--- a/Sources/D2Commands/emoji/CreateEmojiCommand.swift
+++ b/Sources/D2Commands/emoji/CreateEmojiCommand.swift
@@ -12,7 +12,7 @@ public class CreateEmojiCommand: Command {
     public init() {}
 
     public func invoke(with input: RichValue, output: any CommandOutput, context: CommandContext) {
-        guard let client = context.client, let guild = context.guild else {
+        guard let sink = context.sink, let guild = context.guild else {
             output.append(errorText: "Please make sure that a client and a guild exists!")
             return
         }
@@ -27,7 +27,7 @@ public class CreateEmojiCommand: Command {
             return
         }
 
-        client.createEmoji(on: guild.id, name: name, image: encoded)
+        sink.createEmoji(on: guild.id, name: name, image: encoded)
             .listen {
                 do {
                     guard let emoji = try $0.get() else {

--- a/Sources/D2Commands/emoji/DeleteEmojiCommand.swift
+++ b/Sources/D2Commands/emoji/DeleteEmojiCommand.swift
@@ -11,7 +11,7 @@ public class DeleteEmojiCommand: StringCommand {
     public init() {}
 
     public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
-        guard let client = context.client, let guild = context.guild else {
+        guard let sink = context.sink, let guild = context.guild else {
             output.append(errorText: "Please make sure that a client and a guild exists!")
             return
         }
@@ -24,7 +24,7 @@ public class DeleteEmojiCommand: StringCommand {
             return
         }
 
-        client.deleteEmoji(from: guild.id, emojiId: emojiId)
+        sink.deleteEmoji(from: guild.id, emojiId: emojiId)
             .listen {
                 if (try? $0.get()) ?? false {
                     output.append("Successfully deleted emoji!")

--- a/Sources/D2Commands/fun/DiscordinderCommand.swift
+++ b/Sources/D2Commands/fun/DiscordinderCommand.swift
@@ -132,7 +132,7 @@ public class DiscordinderCommand: StringCommand {
         context.unsubscribeFromChannel()
     }
 
-    private func embedOf(member: Guild.Member, presence: Presence?, client: any MessageClient) -> Embed {
+    private func embedOf(member: Guild.Member, presence: Presence?, client: any MessageIOSink) -> Embed {
         Embed(
             title: member.displayName,
             description: (presence?.activities.first).map { descriptionOf(activity: $0) },

--- a/Sources/D2Commands/fun/DiscordinderCommand.swift
+++ b/Sources/D2Commands/fun/DiscordinderCommand.swift
@@ -132,7 +132,7 @@ public class DiscordinderCommand: StringCommand {
         context.unsubscribeFromChannel()
     }
 
-    private func embedOf(member: Guild.Member, presence: Presence?, client: any MessageIOSink) -> Embed {
+    private func embedOf(member: Guild.Member, presence: Presence?, client: any Sink) -> Embed {
         Embed(
             title: member.displayName,
             description: (presence?.activities.first).map { descriptionOf(activity: $0) },

--- a/Sources/D2Commands/fun/DiscordinderCommand.swift
+++ b/Sources/D2Commands/fun/DiscordinderCommand.swift
@@ -80,7 +80,7 @@ public class DiscordinderCommand: StringCommand {
             output.append(errorText: "Not on a guild!")
             return false
         }
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "No client")
             return false
         }
@@ -110,7 +110,7 @@ public class DiscordinderCommand: StringCommand {
         }
         let candidatePresence = guild.presences[candidateId]
 
-        client.sendMessage(Message(embed: embedOf(member: candidate, presence: candidatePresence, client: client)), to: channelId).listenOrLogError { sentMessage in
+        sink.sendMessage(Message(embed: embedOf(member: candidate, presence: candidatePresence, sink: sink)), to: channelId).listenOrLogError { sentMessage in
             guard let messageId = sentMessage?.id else { return }
 
             context.subscribeToChannel()
@@ -119,7 +119,7 @@ public class DiscordinderCommand: StringCommand {
 
             let reactions = [rejectEmoji, ignoreEmoji, acceptEmoji]
             for reaction in reactions {
-                client.createReaction(for: messageId, on: channelId, emoji: reaction)
+                sink.createReaction(for: messageId, on: channelId, emoji: reaction)
             }
         }
 
@@ -132,11 +132,11 @@ public class DiscordinderCommand: StringCommand {
         context.unsubscribeFromChannel()
     }
 
-    private func embedOf(member: Guild.Member, presence: Presence?, client: any Sink) -> Embed {
+    private func embedOf(member: Guild.Member, presence: Presence?, sink: any Sink) -> Embed {
         Embed(
             title: member.displayName,
             description: (presence?.activities.first).map { descriptionOf(activity: $0) },
-            image: client.avatarUrlForUser(member.user.id, with: member.user.avatar, size: 256).map(Embed.Image.init)
+            image: sink.avatarUrlForUser(member.user.id, with: member.user.avatar, size: 256).map(Embed.Image.init)
         )
     }
 

--- a/Sources/D2Commands/fun/HugCommand.swift
+++ b/Sources/D2Commands/fun/HugCommand.swift
@@ -25,7 +25,7 @@ public class HugCommand: Command {
             output.append(errorText: "Please mention someone!")
             return
         }
-        guard let avatarUrl = context.client?.avatarUrlForUser(user.id, with: user.avatar, size: 128, preferredExtension: "png") else {
+        guard let avatarUrl = context.sink?.avatarUrlForUser(user.id, with: user.avatar, size: 128, preferredExtension: "png") else {
             output.append(errorText: "Could not fetch avatar URL")
             return
         }

--- a/Sources/D2Commands/fun/NeverHaveIEverCommand.swift
+++ b/Sources/D2Commands/fun/NeverHaveIEverCommand.swift
@@ -32,7 +32,7 @@ public class NeverHaveIEverCommand: StringCommand {
         guard let messageId = context.message.id, let channelId = context.message.channelId else { return }
 
         for emoji in ["🍹", "❌"] {
-            context.client?.createReaction(for: messageId, on: channelId, emoji: emoji)
+            context.sink?.createReaction(for: messageId, on: channelId, emoji: emoji)
         }
     }
 }

--- a/Sources/D2Commands/fun/PatCommand.swift
+++ b/Sources/D2Commands/fun/PatCommand.swift
@@ -48,7 +48,7 @@ public class PatCommand: Command {
             output.append(errorText: "No author")
             return
         }
-        guard let avatarUrl = context.client?.avatarUrlForUser(user.id, with: user.avatar, size: 128, preferredExtension: "png") else {
+        guard let avatarUrl = context.sink?.avatarUrlForUser(user.id, with: user.avatar, size: 128, preferredExtension: "png") else {
             output.append(errorText: "Could not fetch avatar URL")
             return
         }

--- a/Sources/D2Commands/fun/RickrollCommand.swift
+++ b/Sources/D2Commands/fun/RickrollCommand.swift
@@ -15,7 +15,7 @@ public class RickrollCommand: Command {
             output.append(errorText: "No message/channel id available")
             return
         }
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "No client available")
             return
         }
@@ -29,7 +29,7 @@ public class RickrollCommand: Command {
         if keepMessage {
             rickroll(output: output, mentions: mentions)
         } else {
-            client.deleteMessage(messageId, on: channelId).listenOrLogError { _ in
+            sink.deleteMessage(messageId, on: channelId).listenOrLogError { _ in
                 self.rickroll(output: output, mentions: mentions)
             }
         }

--- a/Sources/D2Commands/fun/WouldYouRatherCommand.swift
+++ b/Sources/D2Commands/fun/WouldYouRatherCommand.swift
@@ -36,7 +36,7 @@ public class WouldYouRatherCommand: StringCommand {
 
     public func onSuccessfullySent(context: CommandContext) {
         guard let messageId = context.message.id, let channelId = context.message.channelId else { return }
-        context.client?.createReaction(for: messageId, on: channelId, emoji: emojiA)
-        context.client?.createReaction(for: messageId, on: channelId, emoji: emojiB)
+        context.sink?.createReaction(for: messageId, on: channelId, emoji: emojiA)
+        context.sink?.createReaction(for: messageId, on: channelId, emoji: emojiB)
     }
 }

--- a/Sources/D2Commands/game/GameCommand.swift
+++ b/Sources/D2Commands/game/GameCommand.swift
@@ -166,8 +166,8 @@ public class GameCommand<G: Game>: Command {
     public func onSubscriptionMessage(with content: String, output: any CommandOutput, context: CommandContext) {
         guard let author = context.author.map({ gamePlayer(from: $0, context: context) }) else { return }
 
-        if let actionArgs = actionMessageRegex.firstGroups(in: content), let channel = context.channel, let client = context.client {
-            let channelName = client.guildForChannel(channel.id)?.channels[channel.id]?.name
+        if let actionArgs = actionMessageRegex.firstGroups(in: content), let channel = context.channel, let sink = context.sink {
+            let channelName = sink.guildForChannel(channel.id)?.channels[channel.id]?.name
             let continueSubscription = perform(actionArgs[1], withArgs: actionArgs[2], on: channel.id, channelName: channelName, output: output, author: author)
             if !continueSubscription {
                 context.unsubscribeFromChannel()
@@ -176,7 +176,7 @@ public class GameCommand<G: Game>: Command {
     }
 
     private func gamePlayer(from user: User, context: CommandContext) -> GamePlayer {
-        GamePlayer(from: user, isAutomatic: user.id == context.client?.me?.id)
+        GamePlayer(from: user, isAutomatic: user.id == context.sink?.me?.id)
     }
 
     /// Performs a game action if present, otherwise does nothing. Returns whether to continue the subscription.

--- a/Sources/D2Commands/imaging/AvatarCommand.swift
+++ b/Sources/D2Commands/imaging/AvatarCommand.swift
@@ -30,7 +30,7 @@ public class AvatarCommand: Command {
             output.append(errorText: "Mention someone to begin!")
             return
         }
-        guard let avatarUrl = context.client?.avatarUrlForUser(user.id, with: user.avatar, preferredExtension: preferredExtension) else {
+        guard let avatarUrl = context.sink?.avatarUrlForUser(user.id, with: user.avatar, preferredExtension: preferredExtension) else {
             output.append(errorText: "Could not fetch avatar URL")
             return
         }

--- a/Sources/D2Commands/imaging/AvatarUrlCommand.swift
+++ b/Sources/D2Commands/imaging/AvatarUrlCommand.swift
@@ -26,7 +26,7 @@ public class AvatarUrlCommand: Command {
             output.append(errorText: "Mention someone to begin!")
             return
         }
-        guard let avatarUrl = context.client?.avatarUrlForUser(user.id, with: user.avatar) else {
+        guard let avatarUrl = context.sink?.avatarUrlForUser(user.id, with: user.avatar) else {
             output.append(errorText: "Could not fetch avatar URL")
             return
         }

--- a/Sources/D2Commands/meta/IOPlatformCommand.swift
+++ b/Sources/D2Commands/meta/IOPlatformCommand.swift
@@ -9,6 +9,6 @@ public class IOPlatformCommand: VoidCommand {
     public init() {}
 
     public func invoke(output: any CommandOutput, context: CommandContext) {
-        output.append("You are talking with me via `\(context.client?.name ?? "?")`.")
+        output.append("You are talking with me via `\(context.sink?.name ?? "?")`.")
     }
 }

--- a/Sources/D2Commands/meta/PresenceCommand.swift
+++ b/Sources/D2Commands/meta/PresenceCommand.swift
@@ -26,12 +26,12 @@ public class PresenceCommand: StringCommand {
             let status = parsedArgs[2].nilIfEmpty.flatMap { Presence.Status(rawValue: $0) } ?? .online
             let customText = parsedArgs[3]
 
-            guard let client = context.client else {
+            guard let sink = context.sink else {
                 output.append(errorText: "No client found")
                 return
             }
 
-            client.setPresence(PresenceUpdate(activities: [Presence.Activity(name: customText, type: activityType)], status: status))
+            sink.setPresence(PresenceUpdate(activities: [Presence.Activity(name: customText, type: activityType)], status: status))
         } else {
             output.append(errorText: "Syntax: [\(activityTypes.keys.joined(separator: "|"))] [\(availableStatusTypes)]? [custom text]")
         }

--- a/Sources/D2Commands/misc/ConversateCommand.swift
+++ b/Sources/D2Commands/misc/ConversateCommand.swift
@@ -22,7 +22,7 @@ public class ConversateCommand: StringCommand {
     }
 
     public func onSubscriptionMessage(with content: String, output: any CommandOutput, context: CommandContext) {
-        guard context.author?.id != context.client?.me?.id, let guildId = context.guild?.id else { return }
+        guard context.author?.id != context.sink?.me?.id, let guildId = context.guild?.id else { return }
         if content == "stop" {
             context.unsubscribeFromChannel()
             output.append("Unsubscribed from this channel.")

--- a/Sources/D2Commands/misc/CycleThroughCommand.swift
+++ b/Sources/D2Commands/misc/CycleThroughCommand.swift
@@ -32,13 +32,13 @@ public class CycleThroughCommand: StringCommand {
             return
         }
 
-        let client = context.client!
+        let sink = context.sink!
         let channelId = context.channel!.id
 
-        client.sendMessage(Message(content: String(firstFrame)), to: channelId).listenOrLogError { sentMessage in
+        sink.sendMessage(Message(content: String(firstFrame)), to: channelId).listenOrLogError { sentMessage in
             self.timer.schedule(nTimes: self.loops * frames.count) { i, _ in
                 let frame = String(frames[i % frames.count])
-                client.editMessage(sentMessage!.id!, on: channelId, content: frame)
+                sink.editMessage(sentMessage!.id!, on: channelId, content: frame)
             }
         }
     }

--- a/Sources/D2Commands/misc/DebugWeatherReactionsCommand.swift
+++ b/Sources/D2Commands/misc/DebugWeatherReactionsCommand.swift
@@ -13,7 +13,7 @@ public class DebugWeatherReactionsCommand: StringCommand {
     public init() {}
 
     public func invoke(with input: String, output: CommandOutput, context: CommandContext) {
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "No client available")
             return
         }
@@ -44,7 +44,7 @@ public class DebugWeatherReactionsCommand: StringCommand {
 
         for weather in weathers {
             if let emoji = OpenWeatherMapWeather.Weather.emojiFor(main: weather.main, description: weather.description) {
-                client.createReaction(for: messageId, on: channelId, emoji: emoji)
+                sink.createReaction(for: messageId, on: channelId, emoji: emoji)
             } else {
                 log.warning("Weather \(weather) has no emoji representation")
             }

--- a/Sources/D2Commands/misc/MessageDatabase.swift
+++ b/Sources/D2Commands/misc/MessageDatabase.swift
@@ -72,7 +72,7 @@ public class MessageDatabase: MarkovPredictor {
         db = try Connection("local/messages.sqlite3")
     }
 
-    public func setupTables(client: any Sink) throws {
+    public func setupTables(sink: any Sink) throws {
         try db.transaction {
             try db.run(guilds.create(ifNotExists: true) {
                 $0.column(guildId, primaryKey: true)
@@ -161,8 +161,8 @@ public class MessageDatabase: MarkovPredictor {
         try db.prepare(sql, values)
     }
 
-    private func insertMessages(with client: any Sink, from id: ChannelID, selection: MessageSelection? = nil) -> Promise<MessageID?, any Error> {
-        client.getMessages(for: id, limit: client.messageFetchLimit ?? 20, selection: selection)
+    private func insertMessages(with sink: any Sink, from id: ChannelID, selection: MessageSelection? = nil) -> Promise<MessageID?, any Error> {
+        sink.getMessages(for: id, limit: sink.messageFetchLimit ?? 20, selection: selection)
             .mapCatching { messages -> MessageID? in
                 guard !messages.isEmpty else { return nil }
 
@@ -180,15 +180,15 @@ public class MessageDatabase: MarkovPredictor {
             .then {
                 if let msgId = $0 {
                     log.info("Fetching messages before \(msgId)")
-                    return self.insertMessages(with: client, from: id, selection: .before(msgId))
+                    return self.insertMessages(with: sink, from: id, selection: .before(msgId))
                 } else {
                     return Promise(.success(nil))
                 }
             }
     }
 
-    public func rebuildMessages(with client: any Sink, from id: GuildID, debugMode: Bool = false, progressListener: ((String) -> Void)? = nil) -> Promise<Void, any Error> {
-        guard let guild = client.guild(for: id) else { return Promise(.failure(MessageDatabaseError.invalidID("\(id)"))) }
+    public func rebuildMessages(with sink: any Sink, from id: GuildID, debugMode: Bool = false, progressListener: ((String) -> Void)? = nil) -> Promise<Void, any Error> {
+        guard let guild = sink.guild(for: id) else { return Promise(.failure(MessageDatabaseError.invalidID("\(id)"))) }
 
         do {
             log.notice("Rebuilding messages in database...")
@@ -196,11 +196,11 @@ public class MessageDatabase: MarkovPredictor {
 
             let guildChannels = debugMode ? guild.channels.prefix(10).compactMap { $0 } : Array(guild.channels)
             let promises: [Promise<Void, any Error>] = guildChannels.map { ch in
-                client.isGuildTextChannel(ch.key).then {
+                sink.isGuildTextChannel(ch.key).then {
                     if $0 {
                         log.info("Fetching messages from channel \(ch.value.name)")
                         progressListener?(ch.value.name)
-                        return self.insertMessages(with: client, from: ch.key).void()
+                        return self.insertMessages(with: sink, from: ch.key).void()
                     } else {
                         return Promise(.success(()))
                     }

--- a/Sources/D2Commands/misc/MessageDatabase.swift
+++ b/Sources/D2Commands/misc/MessageDatabase.swift
@@ -72,7 +72,7 @@ public class MessageDatabase: MarkovPredictor {
         db = try Connection("local/messages.sqlite3")
     }
 
-    public func setupTables(client: any MessageClient) throws {
+    public func setupTables(client: any MessageIOSink) throws {
         try db.transaction {
             try db.run(guilds.create(ifNotExists: true) {
                 $0.column(guildId, primaryKey: true)
@@ -161,7 +161,7 @@ public class MessageDatabase: MarkovPredictor {
         try db.prepare(sql, values)
     }
 
-    private func insertMessages(with client: any MessageClient, from id: ChannelID, selection: MessageSelection? = nil) -> Promise<MessageID?, any Error> {
+    private func insertMessages(with client: any MessageIOSink, from id: ChannelID, selection: MessageSelection? = nil) -> Promise<MessageID?, any Error> {
         client.getMessages(for: id, limit: client.messageFetchLimit ?? 20, selection: selection)
             .mapCatching { messages -> MessageID? in
                 guard !messages.isEmpty else { return nil }
@@ -187,7 +187,7 @@ public class MessageDatabase: MarkovPredictor {
             }
     }
 
-    public func rebuildMessages(with client: any MessageClient, from id: GuildID, debugMode: Bool = false, progressListener: ((String) -> Void)? = nil) -> Promise<Void, any Error> {
+    public func rebuildMessages(with client: any MessageIOSink, from id: GuildID, debugMode: Bool = false, progressListener: ((String) -> Void)? = nil) -> Promise<Void, any Error> {
         guard let guild = client.guild(for: id) else { return Promise(.failure(MessageDatabaseError.invalidID("\(id)"))) }
 
         do {

--- a/Sources/D2Commands/misc/MessageDatabase.swift
+++ b/Sources/D2Commands/misc/MessageDatabase.swift
@@ -72,7 +72,7 @@ public class MessageDatabase: MarkovPredictor {
         db = try Connection("local/messages.sqlite3")
     }
 
-    public func setupTables(client: any MessageIOSink) throws {
+    public func setupTables(client: any Sink) throws {
         try db.transaction {
             try db.run(guilds.create(ifNotExists: true) {
                 $0.column(guildId, primaryKey: true)
@@ -161,7 +161,7 @@ public class MessageDatabase: MarkovPredictor {
         try db.prepare(sql, values)
     }
 
-    private func insertMessages(with client: any MessageIOSink, from id: ChannelID, selection: MessageSelection? = nil) -> Promise<MessageID?, any Error> {
+    private func insertMessages(with client: any Sink, from id: ChannelID, selection: MessageSelection? = nil) -> Promise<MessageID?, any Error> {
         client.getMessages(for: id, limit: client.messageFetchLimit ?? 20, selection: selection)
             .mapCatching { messages -> MessageID? in
                 guard !messages.isEmpty else { return nil }
@@ -187,7 +187,7 @@ public class MessageDatabase: MarkovPredictor {
             }
     }
 
-    public func rebuildMessages(with client: any MessageIOSink, from id: GuildID, debugMode: Bool = false, progressListener: ((String) -> Void)? = nil) -> Promise<Void, any Error> {
+    public func rebuildMessages(with client: any Sink, from id: GuildID, debugMode: Bool = false, progressListener: ((String) -> Void)? = nil) -> Promise<Void, any Error> {
         guard let guild = client.guild(for: id) else { return Promise(.failure(MessageDatabaseError.invalidID("\(id)"))) }
 
         do {

--- a/Sources/D2Commands/misc/MessageDatabaseCommand.swift
+++ b/Sources/D2Commands/misc/MessageDatabaseCommand.swift
@@ -24,12 +24,12 @@ public class MessageDatabaseCommand: StringCommand {
                 output.append("Successfully generated/updated \(count) \("transition".pluralized(with: count))")
             },
             "debugRebuild": { [unowned self] output, context in
-                guard let client = context.client, let guildId = context.guild?.id else {
+                guard let sink = context.sink, let guildId = context.guild?.id else {
                     output.append(errorText: "Debug-rebuilding the message database requires a client and a guild")
                     return
                 }
                 output.append("Debug-rebuilding database...")
-                self.messageDB.rebuildMessages(with: client, from: guildId, debugMode: true) {
+                self.messageDB.rebuildMessages(with: sink, from: guildId, debugMode: true) {
                     output.append("Querying channel `\($0)`...")
                 }.listen {
                     do {
@@ -41,12 +41,12 @@ public class MessageDatabaseCommand: StringCommand {
                 }
             },
             "rebuild": { [unowned self] output, context in
-                guard let client = context.client, let guildId = context.guild?.id else {
+                guard let sink = context.sink, let guildId = context.guild?.id else {
                     output.append(errorText: "Rebuilding the message database requires a client and a guild")
                     return
                 }
                 output.append("Rebuilding database...")
-                self.messageDB.rebuildMessages(with: client, from: guildId) {
+                self.messageDB.rebuildMessages(with: sink, from: guildId) {
                     log.info("Querying channel `\($0)`...")
                 }.listen {
                     do {

--- a/Sources/D2Commands/misc/PetitionCommand.swift
+++ b/Sources/D2Commands/misc/PetitionCommand.swift
@@ -24,6 +24,6 @@ public class PetitionCommand: StringCommand {
     public func onSuccessfullySent(context: CommandContext) {
         guard let messageId = context.message.id, let channelId = context.message.channelId else { return }
 
-        context.client?.createReaction(for: messageId, on: channelId, emoji: "✍️")
+        context.sink?.createReaction(for: messageId, on: channelId, emoji: "✍️")
     }
 }

--- a/Sources/D2Commands/misc/PollCommand.swift
+++ b/Sources/D2Commands/misc/PollCommand.swift
@@ -39,7 +39,7 @@ public class PollCommand: StringCommand {
                 output.append(errorText: "Too many options!")
                 return
             }
-            guard let client = context.client else {
+            guard let sink = context.sink else {
                 output.append(errorText: "Missing client")
                 return
             }
@@ -61,10 +61,10 @@ public class PollCommand: StringCommand {
                 reactions = range.compactMap { numberEmojiOf(digit: $0) }
             }
 
-            client.sendMessage(Message(embed: embed), to: channelId).listenOrLogError { sentMessage in
+            sink.sendMessage(Message(embed: embed), to: channelId).listenOrLogError { sentMessage in
                 if let nextMessageId = sentMessage?.id {
                     for reaction in reactions {
-                        client.createReaction(for: nextMessageId, on: channelId, emoji: reaction)
+                        sink.createReaction(for: nextMessageId, on: channelId, emoji: reaction)
                     }
                 }
             }

--- a/Sources/D2Commands/misc/PortalCommand.swift
+++ b/Sources/D2Commands/misc/PortalCommand.swift
@@ -84,7 +84,7 @@ public class PortalCommand: StringCommand {
 
     private func endpointName(context: CommandContext) -> String {
         let channelName = context.channel.flatMap { channel in context.guild.map { "\($0.channels[channel.id]?.name ?? "<unnamed channel>") on server \($0.name)" } } ?? "<unknown channel>"
-        let platformName = context.client?.name ?? "<unknown platform>"
+        let platformName = context.sink?.name ?? "<unknown platform>"
         return "\(channelName) (\(platformName))"
     }
 

--- a/Sources/D2Commands/misc/SongChartsCommand.swift
+++ b/Sources/D2Commands/misc/SongChartsCommand.swift
@@ -51,7 +51,7 @@ public class SongChartsCommand: StringCommand {
             "tracked": { [unowned self] output, context in
                 output.append(Embed(
                     title: "Tracked Guilds",
-                    description: self.trackedGuilds.compactMap { context.client?.guild(for: $0) }.map { $0.name }.joined(separator: "\n"),
+                    description: self.trackedGuilds.compactMap { context.sink?.guild(for: $0) }.map { $0.name }.joined(separator: "\n"),
                     footer: Embed.Footer(text: "Guilds for which anonymized song statistics are collected")
                 ))
             },

--- a/Sources/D2Commands/misc/SortByCommand.swift
+++ b/Sources/D2Commands/misc/SortByCommand.swift
@@ -31,7 +31,7 @@ public class SortByCommand: StringCommand {
             return
         }
 
-        context.client?.getMessages(for: channel, limit: 80).listenOrLogError { messages in
+        context.sink?.getMessages(for: channel, limit: 80).listenOrLogError { messages in
             let sorted = messages.sorted(by: criterion)
             output.append(Embed(
                 title: ":star: Top messages",

--- a/Sources/D2Commands/misc/TLDRCommand.swift
+++ b/Sources/D2Commands/misc/TLDRCommand.swift
@@ -29,7 +29,7 @@ public class TLDRCommand: StringCommand {
     }
 
     public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
-        guard let client = context.client, let channelId = context.channel?.id else {
+        guard let sink = context.sink, let channelId = context.channel?.id else {
             output.append(errorText: "No MessageIO client/channel/guild available")
             return
         }
@@ -38,7 +38,7 @@ public class TLDRCommand: StringCommand {
             return
         }
 
-        let tldrChannelName = parsedArgs[1].nilIfEmpty.map { ID($0, clientName: client.name) } ?? channelId
+        let tldrChannelName = parsedArgs[1].nilIfEmpty.map { ID($0, clientName: sink.name) } ?? channelId
         let messageCount = parsedArgs[2].nilIfEmpty.flatMap(Int.init) ?? 80
 
         guard messageCount <= maxMessageCount else {
@@ -48,7 +48,7 @@ public class TLDRCommand: StringCommand {
 
         // TODO: Support more messages using message db
 
-        client.getMessages(for: tldrChannelName, limit: messageCount).listenOrLogError { messages in
+        sink.getMessages(for: tldrChannelName, limit: messageCount).listenOrLogError { messages in
             let sentences = messages
                 .sorted(by: ascendingComparator { $0.timestamp ?? .distantPast })
                 .flatMap { $0.content.split(separator: ".").map(String.init) }

--- a/Sources/D2Commands/misc/UserInfoCommand.swift
+++ b/Sources/D2Commands/misc/UserInfoCommand.swift
@@ -35,7 +35,7 @@ public class UserInfoCommand: Command {
 
         output.append(Embed(
             title: "\(user.username)#\(user.discriminator)",
-            thumbnail: context.client?.name == "Discord"
+            thumbnail: context.sink?.name == "Discord"
                 ? URL(string: "https://cdn.discordapp.com/avatars/\(user.id)/\(user.avatar).png?size=128").map { Embed.Thumbnail(url: $0) }
                 : nil,
             footer: Embed.Footer(text: "ID: \(user.id)"),

--- a/Sources/D2Commands/moderation/ChannelMessageCommand.swift
+++ b/Sources/D2Commands/moderation/ChannelMessageCommand.swift
@@ -19,7 +19,7 @@ public class ChannelMessageCommand: StringCommand {
             return
         }
 
-        guard let platform = parsedArgs[1].nilIfEmpty ?? context.client?.name else {
+        guard let platform = parsedArgs[1].nilIfEmpty ?? context.sink?.name else {
             output.append(errorText: "No platform found")
             return
         }

--- a/Sources/D2Commands/moderation/GuildChannelsCommand.swift
+++ b/Sources/D2Commands/moderation/GuildChannelsCommand.swift
@@ -11,7 +11,7 @@ public class GuildChannelsCommand: StringCommand {
     public init() {}
 
     public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "No client available!")
             return
         }
@@ -27,11 +27,11 @@ public class GuildChannelsCommand: StringCommand {
             guildId = guild.id
             useChannelLinks = true
         } else {
-            guildId = GuildID(input, clientName: client.name)
+            guildId = GuildID(input, clientName: sink.name)
             useChannelLinks = false
         }
 
-        guard let guild = client.guild(for: guildId) else {
+        guard let guild = sink.guild(for: guildId) else {
             output.append(errorText: "No guild with this id found!")
             return
         }

--- a/Sources/D2Commands/moderation/GuildInfoCommand.swift
+++ b/Sources/D2Commands/moderation/GuildInfoCommand.swift
@@ -26,7 +26,7 @@ public class GuildInfoCommand: VoidCommand {
 
         output.append(Embed(
             title: ":chart_with_upwards_trend: Guild Info for `\(guild.name)`",
-            thumbnail: context.client?.name == "Discord"
+            thumbnail: context.sink?.name == "Discord"
                 ? guild.icon.flatMap { URL(string: "https://cdn.discordapp.com/icons/\(guild.id)/\($0).png").map(Embed.Thumbnail.init(url:)) }
                 : nil,
             fields: computeStats(for: guild)

--- a/Sources/D2Commands/moderation/GuildsCommand.swift
+++ b/Sources/D2Commands/moderation/GuildsCommand.swift
@@ -12,7 +12,7 @@ public class GuildsCommand: VoidCommand {
     public init() {}
 
     public func invoke(output: any CommandOutput, context: CommandContext) {
-        guard let guilds = context.client?.guilds else {
+        guard let guilds = context.sink?.guilds else {
             output.append(errorText: "Could not fetch guilds")
             return
         }

--- a/Sources/D2Commands/moderation/PeekChannelCommand.swift
+++ b/Sources/D2Commands/moderation/PeekChannelCommand.swift
@@ -13,7 +13,7 @@ public class PeekChannelCommand: StringCommand {
     public init() {}
 
     public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "No client available!")
             return
         }
@@ -23,7 +23,7 @@ public class PeekChannelCommand: StringCommand {
         if input.isEmpty {
             parsedId = context.channel?.id
         } else {
-            parsedId = idPattern.firstGroups(in: input)?.first.map { ChannelID($0, clientName: client.name) }
+            parsedId = idPattern.firstGroups(in: input)?.first.map { ChannelID($0, clientName: sink.name) }
         }
 
         guard let channelId = parsedId else {
@@ -31,7 +31,7 @@ public class PeekChannelCommand: StringCommand {
             return
         }
 
-        client.getMessages(for: channelId, limit: 20).listen {
+        sink.getMessages(for: channelId, limit: 20).listen {
             do {
                 let messages = try $0.get()
                 output.append(Embed(

--- a/Sources/D2Commands/moderation/PronounRoleCommand.swift
+++ b/Sources/D2Commands/moderation/PronounRoleCommand.swift
@@ -25,7 +25,7 @@ public class PronounRoleCommand: StringCommand {
             output.append(errorText: "No guild available")
             return
         }
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "No client available")
             return
         }
@@ -35,7 +35,7 @@ public class PronounRoleCommand: StringCommand {
         }
         let name = parsedInput[1]
         let rawRoleId = parsedInput[2].nilIfEmpty
-        let roleId = rawRoleId.map { RoleID($0, clientName: client.name) }
+        let roleId = rawRoleId.map { RoleID($0, clientName: sink.name) }
 
         var roles = config.pronounRoles[guild.id] ?? [:]
         roles[name] = roleId

--- a/Sources/D2Commands/moderation/PronounsCommand.swift
+++ b/Sources/D2Commands/moderation/PronounsCommand.swift
@@ -53,7 +53,7 @@ public class PronounsCommand: StringCommand {
             output.append(errorText: "Could not add pronouns role due to invalid role id")
             return
         }
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "Could not add pronouns role due to missing client")
             return
         }
@@ -64,11 +64,11 @@ public class PronounsCommand: StringCommand {
 
         let pronounRoles = [RoleID: String](uniqueKeysWithValues: config.pronounRoles[guild.id]?.map { ($0.value, $0.key) } ?? [])
         for otherRoleId in pronounRoles.keys where otherRoleId != roleId {
-            client.removeGuildMemberRole(otherRoleId, from: user.id, on: guild.id, reason: "Pronoun role switched")
+            sink.removeGuildMemberRole(otherRoleId, from: user.id, on: guild.id, reason: "Pronoun role switched")
         }
 
         let roleName = pronounRoles[roleId] ?? "?"
-        client.addGuildMemberRole(roleId, to: user.id, on: guild.id, reason: "Pronoun role added").listen {
+        sink.addGuildMemberRole(roleId, to: user.id, on: guild.id, reason: "Pronoun role added").listen {
             output.append("Switched your pronoun role to \(roleName)!")
             if case .success(false) = $0 {
                 log.warning("Could not add pronoun role \(roleName) (\(roleId)) to \(user.username) (\(user.id))")

--- a/Sources/D2Commands/moderation/ReactCommand.swift
+++ b/Sources/D2Commands/moderation/ReactCommand.swift
@@ -21,7 +21,7 @@ public class ReactCommand: StringCommand {
     }
 
     public func invoke(with input: String, output: CommandOutput, context: CommandContext) {
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "No client available")
             return
         }
@@ -30,13 +30,13 @@ public class ReactCommand: StringCommand {
             return
         }
 
-        let messageId = MessageID(parsedArgs[1], clientName: client.name)
-        let channelId = MessageID(parsedArgs[2], clientName: client.name)
+        let messageId = MessageID(parsedArgs[1], clientName: sink.name)
+        let channelId = MessageID(parsedArgs[2], clientName: sink.name)
         var emojiString = parsedArgs[3]
 
         if !emojiString.unicodeScalars.contains(where: \.properties.isEmoji) {
             // Try resolving the emoji via the guilds
-            let potentialMatches = (client.guilds ?? [])
+            let potentialMatches = (sink.guilds ?? [])
                 .flatMap { $0.emojis.values.filter { $0.name == emojiString } }
             guard let emoji = potentialMatches.first else {
                 output.append(errorText: "Could not find match for emoji \(emojiString)")
@@ -45,10 +45,10 @@ public class ReactCommand: StringCommand {
             emojiString = emoji.compactDescription
         }
 
-        client.createReaction(for: messageId, on: channelId, emoji: emojiString)
+        sink.createReaction(for: messageId, on: channelId, emoji: emojiString)
 
         timer?.schedule(beginImmediately: false) { (_, _) in
-            client.deleteOwnReaction(for: messageId, on: channelId, emoji: emojiString)
+            sink.deleteOwnReaction(for: messageId, on: channelId, emoji: emojiString)
         }
     }
 }

--- a/Sources/D2Commands/moderation/RoleReactionsCommand.swift
+++ b/Sources/D2Commands/moderation/RoleReactionsCommand.swift
@@ -12,7 +12,7 @@ public class RoleReactionsCommand: StringCommand {
         platformAvailability: ["Discord"]
     )
     @AutoSerializing private var configuration: RoleReactionsConfiguration
-    private var subcommands: [String: (CommandOutput, MessageClient, ChannelID, MessageID, String) -> Void] = [:]
+    private var subcommands: [String: (CommandOutput, MessageIOSink, ChannelID, MessageID, String) -> Void] = [:]
 
     public init(configuration: AutoSerializing<RoleReactionsConfiguration>) {
         self._configuration = configuration

--- a/Sources/D2Commands/moderation/RoleReactionsCommand.swift
+++ b/Sources/D2Commands/moderation/RoleReactionsCommand.swift
@@ -12,7 +12,7 @@ public class RoleReactionsCommand: StringCommand {
         platformAvailability: ["Discord"]
     )
     @AutoSerializing private var configuration: RoleReactionsConfiguration
-    private var subcommands: [String: (CommandOutput, MessageIOSink, ChannelID, MessageID, String) -> Void] = [:]
+    private var subcommands: [String: (CommandOutput, Sink, ChannelID, MessageID, String) -> Void] = [:]
 
     public init(configuration: AutoSerializing<RoleReactionsConfiguration>) {
         self._configuration = configuration

--- a/Sources/D2Commands/moderation/RoleReactionsCommand.swift
+++ b/Sources/D2Commands/moderation/RoleReactionsCommand.swift
@@ -17,8 +17,8 @@ public class RoleReactionsCommand: StringCommand {
     public init(configuration: AutoSerializing<RoleReactionsConfiguration>) {
         self._configuration = configuration
         subcommands = [
-            "attach": { [unowned self] output, client, channelId, messageId, args in
-                guard let guild = client.guildForChannel(channelId) else {
+            "attach": { [unowned self] output, sink, channelId, messageId, args in
+                guard let guild = sink.guildForChannel(channelId) else {
                     output.append(errorText: "Not on a guild!")
                     return
                 }
@@ -33,7 +33,7 @@ public class RoleReactionsCommand: StringCommand {
 
                     for (emoji, _) in mappings {
                         // TODO: Handle asynchronous errors properly
-                        client.createReaction(for: messageId, on: channelId, emoji: emoji).listenOrLogError { _ in }
+                        sink.createReaction(for: messageId, on: channelId, emoji: emoji).listenOrLogError { _ in }
                     }
 
                     output.append("Successfully added role reactions to the message.")
@@ -41,7 +41,7 @@ public class RoleReactionsCommand: StringCommand {
                     output.append(error, errorText: "Could not attach role reactions.")
                 }
             },
-            "detach": { [unowned self] output, client, channelId, messageId, _ in
+            "detach": { [unowned self] output, sink, channelId, messageId, _ in
                 guard let mappings = self.configuration.roleMessages[messageId] else {
                     output.append(errorText: "This message is not a (known) reaction message!")
                     return
@@ -51,7 +51,7 @@ public class RoleReactionsCommand: StringCommand {
 
                 for (emoji, _) in mappings {
                     // TODO: Handle asynchronous errors properly
-                    client.deleteOwnReaction(for: messageId, on: channelId, emoji: emoji).listenOrLogError { _ in }
+                    sink.deleteOwnReaction(for: messageId, on: channelId, emoji: emoji).listenOrLogError { _ in }
                 }
 
                 output.append("Successfully removed role reactions from the message.")
@@ -71,14 +71,14 @@ public class RoleReactionsCommand: StringCommand {
             output.append(errorText: info.helpText!)
             return
         }
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             output.append(errorText: "No client available")
             return
         }
 
         let subcommandName = parsedArgs[1]
-        let channelId = ID(parsedArgs[2], clientName: client.name)
-        let messageId = ID(parsedArgs[3], clientName: client.name)
+        let channelId = ID(parsedArgs[2], clientName: sink.name)
+        let messageId = ID(parsedArgs[3], clientName: sink.name)
         let subcommandArgs = parsedArgs[4]
 
         guard let subcommand = subcommands[subcommandName] else {
@@ -86,7 +86,7 @@ public class RoleReactionsCommand: StringCommand {
             return
         }
 
-        subcommand(output, client, channelId, messageId, subcommandArgs)
+        subcommand(output, sink, channelId, messageId, subcommandArgs)
     }
 
     private func parseReactionMappings(from s: String, on guild: Guild) throws -> RoleReactionsConfiguration.Mappings {

--- a/Sources/D2Commands/moderation/ThreadCommand.swift
+++ b/Sources/D2Commands/moderation/ThreadCommand.swift
@@ -40,7 +40,7 @@ public class ThreadCommand: StringCommand {
                 }
                 config.permanentlyArchivedThreadIds.insert(channel.id)
                 output.append("Added `\(channel.name)` to permanently archived threads.")
-                context.client?.modifyChannel(channel.id, with: .init(archived: true)).listenOrLogError { _ in
+                context.sink?.modifyChannel(channel.id, with: .init(archived: true)).listenOrLogError { _ in
                     log.info("Permanently archived `\(channel.name)` upon command")
                 }
             }
@@ -60,7 +60,7 @@ public class ThreadCommand: StringCommand {
             output.append(errorText: "Subcommand `\(input)` not in the subcommands \(subcommands.keys.map { "`\($0)`" }.joined(separator: ", "))")
             return
         }
-        guard let channelId = context.channel?.id, let channel = context.client?.channel(for: channelId) else {
+        guard let channelId = context.channel?.id, let channel = context.sink?.channel(for: channelId) else {
             output.append(errorText: "No channel available")
             return
         }

--- a/Sources/D2Commands/output/MessageIOInteractionOutput.swift
+++ b/Sources/D2Commands/output/MessageIOInteractionOutput.swift
@@ -19,7 +19,7 @@ public class MessageIOInteractionOutput: CommandOutput {
     }
 
     public func append(_ value: RichValue, to channel: OutputChannel) {
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             log.warning("Cannot append to MessageIO without a client!")
             return
         }
@@ -30,18 +30,18 @@ public class MessageIOInteractionOutput: CommandOutput {
 
         // TODO: Split/limit?
         messageWriter.write(value: value)
-            .then { self.send(message: $0, with: client, to: channel) }
+            .then { self.send(message: $0, with: sink, to: channel) }
             .listenOrLogError { _ in }
     }
 
-    private func send(message: Message, with client: any Sink, to channel: OutputChannel) -> Promise<Bool, any Error> {
+    private func send(message: Message, with sink: any Sink, to channel: OutputChannel) -> Promise<Bool, any Error> {
         switch channel {
             case .defaultChannel:
                 guard let token = interaction.token else {
                     return Promise(.failure(MessageIOInteractionOutputError.noInteractionToken))
                 }
                 let response = InteractionResponse(type: .channelMessageWithSource, data: message)
-                return client.createInteractionResponse(for: interaction.id, token: token, response: response)
+                return sink.createInteractionResponse(for: interaction.id, token: token, response: response)
             default:
                 return Promise(.failure(MessageIOInteractionOutputError.onlyDefaultChannelSupported))
         }

--- a/Sources/D2Commands/output/MessageIOInteractionOutput.swift
+++ b/Sources/D2Commands/output/MessageIOInteractionOutput.swift
@@ -34,7 +34,7 @@ public class MessageIOInteractionOutput: CommandOutput {
             .listenOrLogError { _ in }
     }
 
-    private func send(message: Message, with client: any MessageClient, to channel: OutputChannel) -> Promise<Bool, any Error> {
+    private func send(message: Message, with client: any MessageIOSink, to channel: OutputChannel) -> Promise<Bool, any Error> {
         switch channel {
             case .defaultChannel:
                 guard let token = interaction.token else {

--- a/Sources/D2Commands/output/MessageIOInteractionOutput.swift
+++ b/Sources/D2Commands/output/MessageIOInteractionOutput.swift
@@ -34,7 +34,7 @@ public class MessageIOInteractionOutput: CommandOutput {
             .listenOrLogError { _ in }
     }
 
-    private func send(message: Message, with client: any MessageIOSink, to channel: OutputChannel) -> Promise<Bool, any Error> {
+    private func send(message: Message, with client: any Sink, to channel: OutputChannel) -> Promise<Bool, any Error> {
         switch channel {
             case .defaultChannel:
                 guard let token = interaction.token else {

--- a/Sources/D2Commands/output/MessageIOOutput.swift
+++ b/Sources/D2Commands/output/MessageIOOutput.swift
@@ -55,7 +55,7 @@ public class MessageIOOutput: CommandOutput {
             .listenOrLogError { self.onSent?($0) }
     }
 
-    private func send(message: Message, with client: any MessageClient, to channel: OutputChannel) -> Promise<Message?, any Error> {
+    private func send(message: Message, with client: any MessageIOSink, to channel: OutputChannel) -> Promise<Message?, any Error> {
         switch channel {
             case .guildChannel(let id):
                 return client.sendMessage(message, to: id)

--- a/Sources/D2Commands/output/MessageIOOutput.swift
+++ b/Sources/D2Commands/output/MessageIOOutput.swift
@@ -55,7 +55,7 @@ public class MessageIOOutput: CommandOutput {
             .listenOrLogError { self.onSent?($0) }
     }
 
-    private func send(message: Message, with client: any MessageIOSink, to channel: OutputChannel) -> Promise<Message?, any Error> {
+    private func send(message: Message, with client: any Sink, to channel: OutputChannel) -> Promise<Message?, any Error> {
         switch channel {
             case .guildChannel(let id):
                 return client.sendMessage(message, to: id)

--- a/Sources/D2Commands/output/MessageIOOutput.swift
+++ b/Sources/D2Commands/output/MessageIOOutput.swift
@@ -21,7 +21,7 @@ public class MessageIOOutput: CommandOutput {
     }
 
     public func append(_ value: RichValue, to channel: OutputChannel) {
-        guard let client = context.client else {
+        guard let sink = context.sink else {
             log.warning("Cannot append to MessageIO without a client!")
             return
         }
@@ -50,26 +50,26 @@ public class MessageIOOutput: CommandOutput {
                 }
                 return .success(messages)
             }
-            .then { sequence(promises: $0.map { m in { self.send(message: m, with: client, to: channel) } }) }
+            .then { sequence(promises: $0.map { m in { self.send(message: m, with: sink, to: channel) } }) }
             .map { $0.compactMap { $0 } }
             .listenOrLogError { self.onSent?($0) }
     }
 
-    private func send(message: Message, with client: any Sink, to channel: OutputChannel) -> Promise<Message?, any Error> {
+    private func send(message: Message, with sink: any Sink, to channel: OutputChannel) -> Promise<Message?, any Error> {
         switch channel {
             case .guildChannel(let id):
-                return client.sendMessage(message, to: id)
+                return sink.sendMessage(message, to: id)
             case .dmChannel(let id):
-                return client.createDM(with: id)
+                return sink.createDM(with: id)
                     .thenCatching { channelId in
                         guard let id = channelId else {
                             throw MessageIOOutputError.couldNotSendDM
                         }
-                        return client.sendMessage(message, to: id)
+                        return sink.sendMessage(message, to: id)
                     }
             case .defaultChannel:
                 if let textChannelId = self.context.channel?.id {
-                    return client.sendMessage(message, to: textChannelId)
+                    return sink.sendMessage(message, to: textChannelId)
                 } else {
                     return Promise(.failure(MessageIOOutputError.noDefaultChannelAvailable))
                 }

--- a/Sources/D2Commands/output/PipeOutput.swift
+++ b/Sources/D2Commands/output/PipeOutput.swift
@@ -25,7 +25,7 @@ public class PipeOutput: CommandOutput {
             nextOutput.append(value, to: channel)
         } else {
             log.debug("Piping to \(sink)")
-            msgParser.parse(args, clientName: context.client?.name, guild: context.guild).listenOrLogError {
+            msgParser.parse(args, clientName: context.sink?.name, guild: context.guild).listenOrLogError {
                 let nextInput = $0 + value
                 log.trace("Invoking sink")
                 self.sink.invoke(with: nextInput, output: nextOutput, context: self.context)

--- a/Sources/D2Commands/scripting/CronManager.swift
+++ b/Sources/D2Commands/scripting/CronManager.swift
@@ -12,14 +12,14 @@ public class CronManager {
     private let msgParser: MessageParser = .init()
 
     private let registry: CommandRegistry
-    private let client: any MessageIOSink
+    private let client: any Sink
     private let commandPrefix: String
     private let hostInfo: HostInfo
     private let eventLoopGroup: any EventLoopGroup
 
     public init(
         registry: CommandRegistry,
-        client: any MessageIOSink,
+        client: any Sink,
         commandPrefix: String,
         hostInfo: HostInfo,
         eventLoopGroup: any EventLoopGroup

--- a/Sources/D2Commands/scripting/CronManager.swift
+++ b/Sources/D2Commands/scripting/CronManager.swift
@@ -12,20 +12,20 @@ public class CronManager {
     private let msgParser: MessageParser = .init()
 
     private let registry: CommandRegistry
-    private let client: any Sink
+    private let sink: any Sink
     private let commandPrefix: String
     private let hostInfo: HostInfo
     private let eventLoopGroup: any EventLoopGroup
 
     public init(
         registry: CommandRegistry,
-        client: any Sink,
+        sink: any Sink,
         commandPrefix: String,
         hostInfo: HostInfo,
         eventLoopGroup: any EventLoopGroup
     ) {
         self.registry = registry
-        self.client = client
+        self.sink = sink
         self.commandPrefix = commandPrefix
         self.hostInfo = hostInfo
         self.eventLoopGroup = eventLoopGroup
@@ -56,7 +56,7 @@ public class CronManager {
 
         msgParser.parse(commandArgs).listenOrLogError { [self] input in
             let context = CommandContext(
-                client: client,
+                sink: sink,
                 registry: registry,
                 message: Message(content: "", channelId: schedule.channelId),
                 commandPrefix: commandPrefix,

--- a/Sources/D2Commands/scripting/CronManager.swift
+++ b/Sources/D2Commands/scripting/CronManager.swift
@@ -12,14 +12,14 @@ public class CronManager {
     private let msgParser: MessageParser = .init()
 
     private let registry: CommandRegistry
-    private let client: any MessageClient
+    private let client: any MessageIOSink
     private let commandPrefix: String
     private let hostInfo: HostInfo
     private let eventLoopGroup: any EventLoopGroup
 
     public init(
         registry: CommandRegistry,
-        client: any MessageClient,
+        client: any MessageIOSink,
         commandPrefix: String,
         hostInfo: HostInfo,
         eventLoopGroup: any EventLoopGroup

--- a/Sources/D2Commands/scripting/LastMessageCommand.swift
+++ b/Sources/D2Commands/scripting/LastMessageCommand.swift
@@ -21,9 +21,9 @@ public class LastMessageCommand: Command {
     public init() {}
 
     public func invoke(with input: RichValue, output: any CommandOutput, context: CommandContext) {
-        context.client?.getMessages(for: context.channel!.id, limit: 2)
+        context.sink?.getMessages(for: context.channel!.id, limit: 2)
             .then { Promise(Result.from($0[safely: 1], errorIfNil: LastMessageError.noLastMessage)) }
-            .then { MessageParser().parse(message: $0, clientName: context.client?.name, guild: context.guild) }
+            .then { MessageParser().parse(message: $0, clientName: context.sink?.name, guild: context.guild) }
             .listen {
                 do {
                     output.append(try $0.get())

--- a/Sources/D2DiscordIO/DiscordClientManager.swift
+++ b/Sources/D2DiscordIO/DiscordClientManager.swift
@@ -8,14 +8,14 @@ fileprivate let log = Logger(label: "D2DiscordIO.DiscordClientManager")
 
 public class DiscordClientManager: DiscordClientDelegate {
     private let inner: any MessageDelegate
-    private let combinedClient: CombinedMessageIOSink
+    private let combinedClient: CombinedSink
 
     private let queue: DispatchQueue
     private var discordClient: DiscordClient!
 
     public init(
         inner: any MessageDelegate,
-        combinedClient: CombinedMessageIOSink,
+        combinedClient: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token: String
     ) {
@@ -197,7 +197,7 @@ public class DiscordClientManager: DiscordClientDelegate {
         inner.on(updateEmojis: newEmojis, on: guild.usingMessageIO, client: overlayClient(with: discordClient))
     }
 
-    private func overlayClient(with discordClient: DiscordClient) -> MessageIOSink {
-        OverlayMessageIOSink(inner: combinedClient, name: discordClientName, me: discordClient.user?.usingMessageIO)
+    private func overlayClient(with discordClient: DiscordClient) -> Sink {
+        OverlaySink(inner: combinedClient, name: discordClientName, me: discordClient.user?.usingMessageIO)
     }
 }

--- a/Sources/D2DiscordIO/DiscordClientManager.swift
+++ b/Sources/D2DiscordIO/DiscordClientManager.swift
@@ -8,14 +8,14 @@ fileprivate let log = Logger(label: "D2DiscordIO.DiscordClientManager")
 
 public class DiscordClientManager: DiscordClientDelegate {
     private let inner: any MessageDelegate
-    private let combinedClient: CombinedMessageClient
+    private let combinedClient: CombinedMessageIOSink
 
     private let queue: DispatchQueue
     private var discordClient: DiscordClient!
 
     public init(
         inner: any MessageDelegate,
-        combinedClient: CombinedMessageClient,
+        combinedClient: CombinedMessageIOSink,
         eventLoopGroup: any EventLoopGroup,
         token: String
     ) {
@@ -29,7 +29,7 @@ public class DiscordClientManager: DiscordClientDelegate {
             .eventLoopGroup(eventLoopGroup),
         ])
 
-        combinedClient.register(client: DiscordMessageClient(client: discordClient))
+        combinedClient.register(client: DiscordSink(client: discordClient))
     }
 
     public func connect() {
@@ -197,7 +197,7 @@ public class DiscordClientManager: DiscordClientDelegate {
         inner.on(updateEmojis: newEmojis, on: guild.usingMessageIO, client: overlayClient(with: discordClient))
     }
 
-    private func overlayClient(with discordClient: DiscordClient) -> MessageClient {
-        OverlayMessageClient(inner: combinedClient, name: discordClientName, me: discordClient.user?.usingMessageIO)
+    private func overlayClient(with discordClient: DiscordClient) -> MessageIOSink {
+        OverlayMessageIOSink(inner: combinedClient, name: discordClientName, me: discordClient.user?.usingMessageIO)
     }
 }

--- a/Sources/D2DiscordIO/DiscordInteractionConverter.swift
+++ b/Sources/D2DiscordIO/DiscordInteractionConverter.swift
@@ -4,7 +4,7 @@ import D2MessageIO
 // FROM Discord conversions
 
 extension DiscordInteraction {
-    public func usingMessageIO(with client: any MessageIOSink) -> Interaction {
+    public func usingMessageIO(with client: any Sink) -> Interaction {
         Interaction(
             id: id.usingMessageIO,
             type: type?.usingMessageIO,

--- a/Sources/D2DiscordIO/DiscordInteractionConverter.swift
+++ b/Sources/D2DiscordIO/DiscordInteractionConverter.swift
@@ -4,7 +4,7 @@ import D2MessageIO
 // FROM Discord conversions
 
 extension DiscordInteraction {
-    public func usingMessageIO(with client: any Sink) -> Interaction {
+    public func usingMessageIO(with sink: any Sink) -> Interaction {
         Interaction(
             id: id.usingMessageIO,
             type: type?.usingMessageIO,
@@ -12,7 +12,7 @@ extension DiscordInteraction {
             guildId: guildId.usingMessageIO,
             channelId: channelId.usingMessageIO,
             member: member?.usingMessageIO(in: guildId.usingMessageIO),
-            message: message?.usingMessageIO(with: client),
+            message: message?.usingMessageIO(with: sink),
             token: token,
             version: version
         )

--- a/Sources/D2DiscordIO/DiscordInteractionConverter.swift
+++ b/Sources/D2DiscordIO/DiscordInteractionConverter.swift
@@ -4,7 +4,7 @@ import D2MessageIO
 // FROM Discord conversions
 
 extension DiscordInteraction {
-    public func usingMessageIO(with client: any MessageClient) -> Interaction {
+    public func usingMessageIO(with client: any MessageIOSink) -> Interaction {
         Interaction(
             id: id.usingMessageIO,
             type: type?.usingMessageIO,

--- a/Sources/D2DiscordIO/DiscordMessageConverter.swift
+++ b/Sources/D2DiscordIO/DiscordMessageConverter.swift
@@ -91,7 +91,7 @@ extension Message.Component.SelectMenu.Option: DiscordAPIConvertible {
 // FROM Discord conversions
 
 extension DiscordMessage: MessageIOClientConvertible {
-    public func usingMessageIO(with client: any MessageClient) -> Message {
+    public func usingMessageIO(with client: any MessageIOSink) -> Message {
         let guild = guildId.flatMap { client.guild(for: $0.usingMessageIO) }
         let member = (author?.id).flatMap { guild?.members[$0.usingMessageIO] }
         return Message(

--- a/Sources/D2DiscordIO/DiscordMessageConverter.swift
+++ b/Sources/D2DiscordIO/DiscordMessageConverter.swift
@@ -91,7 +91,7 @@ extension Message.Component.SelectMenu.Option: DiscordAPIConvertible {
 // FROM Discord conversions
 
 extension DiscordMessage: MessageIOClientConvertible {
-    public func usingMessageIO(with client: any MessageIOSink) -> Message {
+    public func usingMessageIO(with client: any Sink) -> Message {
         let guild = guildId.flatMap { client.guild(for: $0.usingMessageIO) }
         let member = (author?.id).flatMap { guild?.members[$0.usingMessageIO] }
         return Message(

--- a/Sources/D2DiscordIO/DiscordMessageConverter.swift
+++ b/Sources/D2DiscordIO/DiscordMessageConverter.swift
@@ -91,8 +91,8 @@ extension Message.Component.SelectMenu.Option: DiscordAPIConvertible {
 // FROM Discord conversions
 
 extension DiscordMessage: MessageIOClientConvertible {
-    public func usingMessageIO(with client: any Sink) -> Message {
-        let guild = guildId.flatMap { client.guild(for: $0.usingMessageIO) }
+    public func usingMessageIO(with sink: any Sink) -> Message {
+        let guild = guildId.flatMap { sink.guild(for: $0.usingMessageIO) }
         let member = (author?.id).flatMap { guild?.members[$0.usingMessageIO] }
         return Message(
             content: content ?? "",

--- a/Sources/D2DiscordIO/DiscordPlatform.swift
+++ b/Sources/D2DiscordIO/DiscordPlatform.swift
@@ -13,14 +13,14 @@ public struct DiscordPlatform: MessagePlatform {
     public var name: String { discordClientName }
 
     public init(
-        with delegate: any MessageDelegate,
+        receiver: any Receiver,
         combinedSink: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token: String
     ) {
         log.info("Initializing Discord backend...")
         manager = DiscordClientManager(
-            inner: delegate,
+            receiver: receiver,
             combinedSink: combinedSink,
             eventLoopGroup: eventLoopGroup,
             token: token

--- a/Sources/D2DiscordIO/DiscordPlatform.swift
+++ b/Sources/D2DiscordIO/DiscordPlatform.swift
@@ -14,7 +14,7 @@ public struct DiscordPlatform: MessagePlatform {
 
     public init(
         with delegate: any MessageDelegate,
-        combinedClient: CombinedMessageIOSink,
+        combinedClient: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token: String
     ) {

--- a/Sources/D2DiscordIO/DiscordPlatform.swift
+++ b/Sources/D2DiscordIO/DiscordPlatform.swift
@@ -14,14 +14,14 @@ public struct DiscordPlatform: MessagePlatform {
 
     public init(
         with delegate: any MessageDelegate,
-        combinedClient: CombinedSink,
+        combinedSink: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token: String
     ) {
         log.info("Initializing Discord backend...")
         manager = DiscordClientManager(
             inner: delegate,
-            combinedClient: combinedClient,
+            combinedSink: combinedSink,
             eventLoopGroup: eventLoopGroup,
             token: token
         )

--- a/Sources/D2DiscordIO/DiscordPlatform.swift
+++ b/Sources/D2DiscordIO/DiscordPlatform.swift
@@ -14,7 +14,7 @@ public struct DiscordPlatform: MessagePlatform {
 
     public init(
         with delegate: any MessageDelegate,
-        combinedClient: CombinedMessageClient,
+        combinedClient: CombinedMessageIOSink,
         eventLoopGroup: any EventLoopGroup,
         token: String
     ) {

--- a/Sources/D2DiscordIO/DiscordSink.swift
+++ b/Sources/D2DiscordIO/DiscordSink.swift
@@ -4,9 +4,9 @@ import D2MessageIO
 import Logging
 import Discord
 
-fileprivate let log = Logger(label: "D2DiscordIO.DiscordMessageClient")
+fileprivate let log = Logger(label: "D2DiscordIO.DiscordSink")
 
-struct DiscordMessageClient: DefaultMessageClient {
+struct DiscordSink: DefaultMessageIOSink {
     private let client: DiscordClient
 
     var name: String { discordClientName }
@@ -60,7 +60,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func addGuildMemberRole(_ roleId: D2MessageIO.RoleID, to userId: D2MessageIO.UserID, on guildId: D2MessageIO.GuildID, reason: String?) -> Promise<Bool, any Error> {
         Promise { then in
             client.addGuildMemberRole(roleId.usingDiscordAPI, to: userId.usingDiscordAPI, on: guildId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -68,7 +68,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func removeGuildMemberRole(_ roleId: D2MessageIO.RoleID, from userId: D2MessageIO.UserID, on guildId: D2MessageIO.GuildID, reason: String?) -> Promise<Bool, any Error> {
         Promise { then in
             client.removeGuildMemberRole(roleId.usingDiscordAPI, from: userId.usingDiscordAPI, on: guildId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -76,7 +76,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func createDM(with userId: D2MessageIO.UserID) -> Promise<D2MessageIO.ChannelID?, any Error> {
         Promise { then in
             client.createDM(with: userId.usingDiscordAPI) {
-                then(Result.from($0?.id.usingMessageIO, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0?.id.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -84,7 +84,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func sendMessage(_ message: Message, to channelId: D2MessageIO.ChannelID) -> Promise<Message?, any Error> {
         Promise { then in
             client.sendMessage(message.usingDiscordAPI, to: channelId.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO(with: self), errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0?.usingMessageIO(with: self), errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -92,7 +92,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func editMessage(_ id: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, content: String) -> Promise<Message?, any Error> {
         Promise { then in
             client.editMessage(id.usingDiscordAPI, on: channelId.usingDiscordAPI, content: content) {
-                then(Result.from($0?.usingMessageIO(with: self), errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0?.usingMessageIO(with: self), errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -100,7 +100,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func deleteMessage(_ id: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
         Promise { then in
             client.deleteMessage(id.usingDiscordAPI, on: channelId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -108,7 +108,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func bulkDeleteMessages(_ ids: [D2MessageIO.MessageID], on channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
         Promise { then in
             client.bulkDeleteMessages(ids.map { $0.usingDiscordAPI }, on: channelId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -116,7 +116,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func getMessages(for channelId: D2MessageIO.ChannelID, limit: Int, selection: MessageSelection?) -> Promise<[Message], any Error> {
         Promise { then in
             client.getMessages(for: channelId.usingDiscordAPI, selection: selection?.usingDiscordAPI, limit: limit) {
-                then(Result.from($0.map { $0.usingMessageIO(with: self) }, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0.map { $0.usingMessageIO(with: self) }, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -124,7 +124,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func modifyChannel(_ channelId: D2MessageIO.ChannelID, with modification: ChannelModification) -> Promise<Channel?, any Error> {
         Promise { then in
             client.modifyChannel(channelId.usingDiscordAPI, options: modification.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -132,7 +132,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func isGuildTextChannel(_ channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
         Promise { then in
             client.getChannel(channelId.usingDiscordAPI) {
-                then(Result.from($0.map { $0.type == .text } ?? false, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0.map { $0.type == .text } ?? false, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -140,7 +140,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func isDMTextChannel(_ channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
         Promise { then in
             client.getChannel(channelId.usingDiscordAPI) {
-                then(Result.from($0.map(\.isDM) ?? false, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0.map(\.isDM) ?? false, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -148,7 +148,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func triggerTyping(on channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
         Promise { then in
             client.triggerTyping(on: channelId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -164,7 +164,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func deleteOwnReaction(for messageId: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, emoji: String) -> Promise<Bool, any Error> {
         Promise { then in
             client.deleteOwnReaction(for: messageId.usingDiscordAPI, on: channelId.usingDiscordAPI, emoji: emoji) {
-                then(Result.from($0, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -172,7 +172,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func deleteUserReaction(for messageId: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, emoji: String, by userId: D2MessageIO.UserID) -> Promise<Bool, any Error> {
         Promise { then in
             client.deleteUserReaction(for: messageId.usingDiscordAPI, on: channelId.usingDiscordAPI, emoji: emoji, by: userId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -180,7 +180,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func createEmoji(on guildId: D2MessageIO.GuildID, name: String, image: String, roles: [D2MessageIO.RoleID]) -> Promise<Emoji?, any Error> {
         Promise { then in
             client.createGuildEmoji(on: guildId.usingDiscordAPI, name: name, image: image, roles: roles.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -188,7 +188,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func deleteEmoji(from guildId: D2MessageIO.GuildID, emojiId: D2MessageIO.EmojiID) -> Promise<Bool, any Error> {
         Promise { then in
             client.deleteGuildEmoji(on: guildId.usingDiscordAPI, for: emojiId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -204,7 +204,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
         Promise { then in
             client.createApplicationCommand(name: name, description: description, options: options?.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -212,7 +212,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
         Promise { then in
             client.editApplicationCommand(commandId.usingDiscordAPI, name: name, description: description, options: options?.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -220,7 +220,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func deleteMIOCommand(_ commandId: MIOCommandID) -> Promise<Bool, any Error> {
         Promise { then in
             client.deleteApplicationCommand(commandId.usingDiscordAPI) {
-                then(Result.from($0 != nil, errorIfNil: DiscordMessageClientError.invalidResponse($0)))
+                then(Result.from($0 != nil, errorIfNil: DiscordSinkError.invalidResponse($0)))
             }
         }
     }
@@ -236,7 +236,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func createMIOCommand(on guildId: D2MessageIO.GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
         Promise { then in
             client.createApplicationCommand(on: guildId.usingDiscordAPI, name: name, description: description, options: options?.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -244,7 +244,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func editMIOCommand(_ commandId: MIOCommandID, on guildId: D2MessageIO.GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
         Promise { then in
             client.editApplicationCommand(commandId.usingDiscordAPI, on: guildId.usingDiscordAPI, name: name, description: description, options: options?.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordMessageClientError.invalidResponse($1)))
+                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
@@ -252,7 +252,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: D2MessageIO.GuildID) -> Promise<Bool, any Error> {
         Promise { then in
             client.deleteApplicationCommand(commandId.usingDiscordAPI, on: guildId.usingDiscordAPI) {
-                then(Result.from($0 != nil, errorIfNil: DiscordMessageClientError.invalidResponse($0)))
+                then(Result.from($0 != nil, errorIfNil: DiscordSinkError.invalidResponse($0)))
             }
         }
     }
@@ -260,7 +260,7 @@ struct DiscordMessageClient: DefaultMessageClient {
     func createInteractionResponse(for interactionId: D2MessageIO.InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, any Error> {
         Promise { then in
             client.createInteractionResponse(for: interactionId.usingDiscordAPI, token: token, response: response.usingDiscordAPI) {
-                then(Result.from($0 != nil, errorIfNil: DiscordMessageClientError.invalidResponse($0)))
+                then(Result.from($0 != nil, errorIfNil: DiscordSinkError.invalidResponse($0)))
             }
         }
     }

--- a/Sources/D2DiscordIO/DiscordSink.swift
+++ b/Sources/D2DiscordIO/DiscordSink.swift
@@ -6,7 +6,7 @@ import Discord
 
 fileprivate let log = Logger(label: "D2DiscordIO.DiscordSink")
 
-struct DiscordSink: DefaultMessageIOSink {
+struct DiscordSink: DefaultSink {
     private let client: DiscordClient
 
     var name: String { discordClientName }

--- a/Sources/D2DiscordIO/DiscordSinkError.swift
+++ b/Sources/D2DiscordIO/DiscordSinkError.swift
@@ -3,6 +3,6 @@ import Foundation
 import FoundationNetworking
 #endif
 
-public enum DiscordMessageClientError: Error {
+public enum DiscordSinkError: Error {
     case invalidResponse(HTTPURLResponse?)
 }

--- a/Sources/D2Handlers/D2Delegate.swift
+++ b/Sources/D2Handlers/D2Delegate.swift
@@ -43,7 +43,7 @@ public class D2Delegate: MessageDelegate {
         mioCommandGuildId: GuildID? = nil,
         logBuffer: LogBuffer,
         eventLoopGroup: any EventLoopGroup,
-        client: any Sink
+        sink: any Sink
     ) throws {
         self.commandPrefix = commandPrefix
         self.hostInfo = hostInfo
@@ -56,7 +56,7 @@ public class D2Delegate: MessageDelegate {
         messageDB = try MessageDatabase()
         partyGameDB = try PartyGameDatabase()
         eventListenerBus = EventListenerBus()
-        cronManager = CronManager(registry: registry, client: client, commandPrefix: commandPrefix, hostInfo: hostInfo, eventLoopGroup: eventLoopGroup)
+        cronManager = CronManager(registry: registry, sink: sink, commandPrefix: commandPrefix, hostInfo: hostInfo, eventLoopGroup: eventLoopGroup)
         subscriptionManager = SubscriptionManager(registry: registry)
         permissionManager = PermissionManager()
         let inventoryManager = InventoryManager()
@@ -461,18 +461,18 @@ public class D2Delegate: MessageDelegate {
         registry["help", aka: ["h"]] = HelpCommand(commandPrefix: commandPrefix, permissionManager: permissionManager)
     }
 
-    public func on(receiveReady: [String: Any], client: any Sink) {
-        let guildCount = client.guilds?.count ?? 0
+    public func on(receiveReady: [String: Any], sink: any Sink) {
+        let guildCount = sink.guilds?.count ?? 0
         log.info("Received ready! \(guildCount) \("guild".pluralized(with: guildCount)) found.")
 
         if let presence = initialPresence {
-            client.setPresence(PresenceUpdate(activities: [Presence.Activity(name: presence, type: .listening)], status: .online))
+            sink.setPresence(PresenceUpdate(activities: [Presence.Activity(name: presence, type: .listening)], status: .online))
         }
 
         eventListenerBus.fire(event: .receiveReady, with: .none) // TODO: Pass data?
 
         do {
-            try messageDB.setupTables(client: client)
+            try messageDB.setupTables(sink: sink)
         } catch {
             log.warning("Could not setup message database: \(error)")
         }
@@ -516,7 +516,7 @@ public class D2Delegate: MessageDelegate {
                 if let guildId = mioCommandGuildId {
                     // Only register MIO commands on guild, if specified
                     // (useful for development)
-                    client.createMIOCommand(
+                    sink.createMIOCommand(
                         on: guildId,
                         name: category.rawValue,
                         description: category.plainDescription,
@@ -524,7 +524,7 @@ public class D2Delegate: MessageDelegate {
                     )
                 } else {
                     // Register MIO commands globally
-                    client.createMIOCommand(
+                    sink.createMIOCommand(
                         name: category.rawValue,
                         description: category.plainDescription,
                         options: options
@@ -539,7 +539,7 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(receivePresenceUpdate presence: Presence, client: any Sink) {
+    public func on(receivePresenceUpdate presence: Presence, sink: any Sink) {
         for (_, entry) in registry {
             if case let .command(command) = entry {
                 command.onReceivedUpdated(presence: presence)
@@ -547,14 +547,14 @@ public class D2Delegate: MessageDelegate {
         }
 
         for i in presenceHandlers.indices {
-            presenceHandlers[i].handle(presenceUpdate: presence, client: client)
+            presenceHandlers[i].handle(presenceUpdate: presence, sink: sink)
         }
 
         // TODO: Pass full presence?
         eventListenerBus.fire(event: .receivePresenceUpdate, with: presence.activities.first.map { RichValue.text($0.name) } ?? .none)
     }
 
-    public func on(createGuild guild: Guild, client: any Sink) {
+    public func on(createGuild guild: Guild, sink: any Sink) {
         do {
             log.info("Inserting guild '\(guild.name)' into message database...")
             try messageDB.insert(guild: guild)
@@ -564,36 +564,36 @@ public class D2Delegate: MessageDelegate {
 
         for (_, presence) in guild.presences {
             for i in presenceHandlers.indices {
-                presenceHandlers[i].handle(presenceUpdate: presence, client: client)
+                presenceHandlers[i].handle(presenceUpdate: presence, sink: sink)
             }
         }
 
         eventListenerBus.fire(event: .createGuild, with: .none) // TODO: Provide guild ID?
     }
 
-    public func on(createMessage message: Message, client: any Sink) {
+    public func on(createMessage message: Message, sink: any Sink) {
         var m = message
 
         for rewriter in messageRewriters {
-            if let rewrite = rewriter.rewrite(message: m, from: client) {
+            if let rewrite = rewriter.rewrite(message: m, sink: sink) {
                 m = rewrite
             }
         }
 
         for i in messageHandlers.indices {
-            if messageHandlers[i].handleRaw(message: message, from: client) {
+            if messageHandlers[i].handleRaw(message: message, sink: sink) {
                 return
             }
-            if messageHandlers[i].handle(message: m, from: client) {
+            if messageHandlers[i].handle(message: m, sink: sink) {
                 return
             }
         }
 
         // Only fire on unhandled messages
-        if m.author?.id != client.me?.id {
-            MessageParser().parse(message: m, clientName: client.name, guild: m.guild).listenOrLogError {
+        if m.author?.id != sink.me?.id {
+            MessageParser().parse(message: m, clientName: sink.name, guild: m.guild).listenOrLogError {
                 self.eventListenerBus.fire(event: .createMessage, with: $0, context: CommandContext(
-                    client: client,
+                    sink: sink,
                     registry: self.registry,
                     message: m,
                     commandPrefix: self.commandPrefix,
@@ -605,36 +605,36 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(createInteraction interaction: Interaction, client: any Sink) {
+    public func on(createInteraction interaction: Interaction, sink: any Sink) {
         for i in interactionHandlers.indices {
-            if interactionHandlers[i].handle(interaction: interaction, client: client) {
+            if interactionHandlers[i].handle(interaction: interaction, sink: sink) {
                 return
             }
         }
     }
 
-    public func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
+    public func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {
         for i in reactionHandlers.indices {
-            reactionHandlers[i].handle(createdReaction: reaction, to: messageId, on: channelId, by: userId, client: client)
+            reactionHandlers[i].handle(createdReaction: reaction, to: messageId, on: channelId, by: userId, sink: sink)
         }
     }
 
-    public func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
+    public func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {
         for i in reactionHandlers.indices {
-            reactionHandlers[i].handle(deletedReaction: reaction, from: messageId, on: channelId, by: userId, client: client)
+            reactionHandlers[i].handle(deletedReaction: reaction, from: messageId, on: channelId, by: userId, sink: sink)
         }
     }
 
-    public func on(removeAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any Sink) {
+    public func on(removeAllReactionsFrom messageId: MessageID, on channelId: ChannelID, sink: any Sink) {
         for i in reactionHandlers.indices {
-            reactionHandlers[i].handle(deletedAllReactionsFrom: messageId, on: channelId, client: client)
+            reactionHandlers[i].handle(deletedAllReactionsFrom: messageId, on: channelId, sink: sink)
         }
     }
 
-    public func on(updateMessage message: Message, client: any Sink) {
-        MessageParser().parse(message: message, clientName: client.name, guild: message.guild).listenOrLogError {
+    public func on(updateMessage message: Message, sink: any Sink) {
+        MessageParser().parse(message: message, clientName: sink.name, guild: message.guild).listenOrLogError {
             self.eventListenerBus.fire(event: .updateMessage, with: $0, context: CommandContext(
-                client: client,
+                sink: sink,
                 registry: self.registry,
                 message: message,
                 commandPrefix: self.commandPrefix,
@@ -645,57 +645,57 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(disconnectWithReason reason: String, client: any Sink) {
+    public func on(disconnectWithReason reason: String, sink: any Sink) {
         eventListenerBus.fire(event: .disconnectWithReason, with: .text(reason))
     }
 
-    public func on(createChannel channel: Channel, client: any Sink) {
+    public func on(createChannel channel: Channel, sink: any Sink) {
         for i in channelHandlers.indices {
-            channelHandlers[i].handle(channelCreate: channel, client: client)
+            channelHandlers[i].handle(channelCreate: channel, sink: sink)
         }
 
         eventListenerBus.fire(event: .createChannel, with: .none) // TODO: Pass channel ID?
     }
 
-    public func on(deleteChannel channel: Channel, client: any Sink) {
+    public func on(deleteChannel channel: Channel, sink: any Sink) {
         for i in channelHandlers.indices {
-            channelHandlers[i].handle(channelDelete: channel, client: client)
+            channelHandlers[i].handle(channelDelete: channel, sink: sink)
         }
 
         eventListenerBus.fire(event: .deleteChannel, with: .none) // TODO: Pass channel ID?
     }
 
-    public func on(updateChannel channel: Channel, client: any Sink) {
+    public func on(updateChannel channel: Channel, sink: any Sink) {
         for i in channelHandlers.indices {
-            channelHandlers[i].handle(channelUpdate: channel, client: client)
+            channelHandlers[i].handle(channelUpdate: channel, sink: sink)
         }
 
         eventListenerBus.fire(event: .updateChannel, with: .none) // TODO: Pass channel ID?
     }
 
-    public func on(createThread thread: Channel, client: any Sink) {
+    public func on(createThread thread: Channel, sink: any Sink) {
         for i in channelHandlers.indices {
-            channelHandlers[i].handle(threadCreate: thread, client: client)
+            channelHandlers[i].handle(threadCreate: thread, sink: sink)
         }
     }
 
-    public func on(deleteThread thread: Channel, client: any Sink) {
+    public func on(deleteThread thread: Channel, sink: any Sink) {
         for i in channelHandlers.indices {
-            channelHandlers[i].handle(threadDelete: thread, client: client)
+            channelHandlers[i].handle(threadDelete: thread, sink: sink)
         }
     }
 
-    public func on(updateThread thread: Channel, client: any Sink) {
+    public func on(updateThread thread: Channel, sink: any Sink) {
         for i in channelHandlers.indices {
-            channelHandlers[i].handle(threadUpdate: thread, client: client)
+            channelHandlers[i].handle(threadUpdate: thread, sink: sink)
         }
     }
 
-    public func on(deleteGuild guild: Guild, client: any Sink) {
+    public func on(deleteGuild guild: Guild, sink: any Sink) {
         eventListenerBus.fire(event: .deleteGuild, with: .none) // TODO: Pass guild ID?
     }
 
-    public func on(updateGuild guild: Guild, client: any Sink) {
+    public func on(updateGuild guild: Guild, sink: any Sink) {
         do {
             log.info("Updating guild '\(guild.name)' in message database...")
             try messageDB.insert(guild: guild)
@@ -706,9 +706,9 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateGuild, with: .none) // TODO: Pass guild ID?
     }
 
-    public func on(addGuildMember member: Guild.Member, client: any Sink) {
+    public func on(addGuildMember member: Guild.Member, sink: any Sink) {
         do {
-            if let guild = client.guild(for: member.guildId) {
+            if let guild = sink.guild(for: member.guildId) {
                 log.info("Inserting member '\(member.displayName)' into message database...")
                 try messageDB.insert(member: member, on: guild)
             }
@@ -719,13 +719,13 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .addGuildMember, with: .mentions([member.user]))
     }
 
-    public func on(removeGuildMember member: Guild.Member, client: any Sink) {
+    public func on(removeGuildMember member: Guild.Member, sink: any Sink) {
         eventListenerBus.fire(event: .removeGuildMember, with: .mentions([member.user]))
     }
 
-    public func on(updateGuildMember member: Guild.Member, client: any Sink) {
+    public func on(updateGuildMember member: Guild.Member, sink: any Sink) {
         do {
-            if let guild = client.guild(for: member.guildId) {
+            if let guild = sink.guild(for: member.guildId) {
                 log.info("Updating member '\(member.displayName)' in message database...")
                 try messageDB.insert(member: member, on: guild)
             }
@@ -736,7 +736,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateGuildMember, with: .mentions([member.user]))
     }
 
-    public func on(createRole role: Role, on guild: Guild, client: any Sink) {
+    public func on(createRole role: Role, on guild: Guild, sink: any Sink) {
         do {
             log.info("Inserting role '\(role.name)' on '\(guild.name)' into message database...")
             try messageDB.insert(role: role, on: guild)
@@ -747,11 +747,11 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .createRole, with: .none) // TODO: Pass role ID/role mention?
     }
 
-    public func on(deleteRole role: Role, from guild: Guild, client: any Sink) {
+    public func on(deleteRole role: Role, from guild: Guild, sink: any Sink) {
         eventListenerBus.fire(event: .deleteRole, with: .none) // TODO: Pass role ID/role mention?
     }
 
-    public func on(updateRole role: Role, on guild: Guild, client: any Sink) {
+    public func on(updateRole role: Role, on guild: Guild, sink: any Sink) {
         do {
             log.info("Updating role '\(role.name)' on '\(guild.name)' in message database...")
             try messageDB.insert(role: role, on: guild)
@@ -762,19 +762,19 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateRole, with: .none) // TODO: Pass role ID/role mention?
     }
 
-    public func on(connect connected: Bool, client: any Sink) {
+    public func on(connect connected: Bool, sink: any Sink) {
         eventListenerBus.fire(event: .connect, with: .none) // TODO: Pass 'connected'?
     }
 
-    public func on(receiveVoiceStateUpdate state: VoiceState, client: any Sink) {
+    public func on(receiveVoiceStateUpdate state: VoiceState, sink: any Sink) {
         eventListenerBus.fire(event: .receiveVoiceStateUpdate, with: .none) // TODO: Pass state?
     }
 
-    public func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any Sink) {
+    public func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, sink: any Sink) {
         eventListenerBus.fire(event: .handleGuildMemberChunk, with: .none) // TODO: Pass state?
     }
 
-    public func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any Sink) {
+    public func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, sink: any Sink) {
         do {
             log.info("Updating emojis on '\(guild.name)' in message database...")
             for emoji in emojis.values {

--- a/Sources/D2Handlers/D2Delegate.swift
+++ b/Sources/D2Handlers/D2Delegate.swift
@@ -43,7 +43,7 @@ public class D2Delegate: MessageDelegate {
         mioCommandGuildId: GuildID? = nil,
         logBuffer: LogBuffer,
         eventLoopGroup: any EventLoopGroup,
-        client: any MessageClient
+        client: any MessageIOSink
     ) throws {
         self.commandPrefix = commandPrefix
         self.hostInfo = hostInfo
@@ -461,7 +461,7 @@ public class D2Delegate: MessageDelegate {
         registry["help", aka: ["h"]] = HelpCommand(commandPrefix: commandPrefix, permissionManager: permissionManager)
     }
 
-    public func on(receiveReady: [String: Any], client: any MessageClient) {
+    public func on(receiveReady: [String: Any], client: any MessageIOSink) {
         let guildCount = client.guilds?.count ?? 0
         log.info("Received ready! \(guildCount) \("guild".pluralized(with: guildCount)) found.")
 
@@ -539,7 +539,7 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(receivePresenceUpdate presence: Presence, client: any MessageClient) {
+    public func on(receivePresenceUpdate presence: Presence, client: any MessageIOSink) {
         for (_, entry) in registry {
             if case let .command(command) = entry {
                 command.onReceivedUpdated(presence: presence)
@@ -554,7 +554,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .receivePresenceUpdate, with: presence.activities.first.map { RichValue.text($0.name) } ?? .none)
     }
 
-    public func on(createGuild guild: Guild, client: any MessageClient) {
+    public func on(createGuild guild: Guild, client: any MessageIOSink) {
         do {
             log.info("Inserting guild '\(guild.name)' into message database...")
             try messageDB.insert(guild: guild)
@@ -571,7 +571,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .createGuild, with: .none) // TODO: Provide guild ID?
     }
 
-    public func on(createMessage message: Message, client: any MessageClient) {
+    public func on(createMessage message: Message, client: any MessageIOSink) {
         var m = message
 
         for rewriter in messageRewriters {
@@ -605,7 +605,7 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(createInteraction interaction: Interaction, client: any MessageClient) {
+    public func on(createInteraction interaction: Interaction, client: any MessageIOSink) {
         for i in interactionHandlers.indices {
             if interactionHandlers[i].handle(interaction: interaction, client: client) {
                 return
@@ -613,25 +613,25 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {
+    public func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
         for i in reactionHandlers.indices {
             reactionHandlers[i].handle(createdReaction: reaction, to: messageId, on: channelId, by: userId, client: client)
         }
     }
 
-    public func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {
+    public func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
         for i in reactionHandlers.indices {
             reactionHandlers[i].handle(deletedReaction: reaction, from: messageId, on: channelId, by: userId, client: client)
         }
     }
 
-    public func on(removeAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageClient) {
+    public func on(removeAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageIOSink) {
         for i in reactionHandlers.indices {
             reactionHandlers[i].handle(deletedAllReactionsFrom: messageId, on: channelId, client: client)
         }
     }
 
-    public func on(updateMessage message: Message, client: any MessageClient) {
+    public func on(updateMessage message: Message, client: any MessageIOSink) {
         MessageParser().parse(message: message, clientName: client.name, guild: message.guild).listenOrLogError {
             self.eventListenerBus.fire(event: .updateMessage, with: $0, context: CommandContext(
                 client: client,
@@ -645,11 +645,11 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(disconnectWithReason reason: String, client: any MessageClient) {
+    public func on(disconnectWithReason reason: String, client: any MessageIOSink) {
         eventListenerBus.fire(event: .disconnectWithReason, with: .text(reason))
     }
 
-    public func on(createChannel channel: Channel, client: any MessageClient) {
+    public func on(createChannel channel: Channel, client: any MessageIOSink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(channelCreate: channel, client: client)
         }
@@ -657,7 +657,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .createChannel, with: .none) // TODO: Pass channel ID?
     }
 
-    public func on(deleteChannel channel: Channel, client: any MessageClient) {
+    public func on(deleteChannel channel: Channel, client: any MessageIOSink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(channelDelete: channel, client: client)
         }
@@ -665,7 +665,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .deleteChannel, with: .none) // TODO: Pass channel ID?
     }
 
-    public func on(updateChannel channel: Channel, client: any MessageClient) {
+    public func on(updateChannel channel: Channel, client: any MessageIOSink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(channelUpdate: channel, client: client)
         }
@@ -673,29 +673,29 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateChannel, with: .none) // TODO: Pass channel ID?
     }
 
-    public func on(createThread thread: Channel, client: any MessageClient) {
+    public func on(createThread thread: Channel, client: any MessageIOSink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(threadCreate: thread, client: client)
         }
     }
 
-    public func on(deleteThread thread: Channel, client: any MessageClient) {
+    public func on(deleteThread thread: Channel, client: any MessageIOSink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(threadDelete: thread, client: client)
         }
     }
 
-    public func on(updateThread thread: Channel, client: any MessageClient) {
+    public func on(updateThread thread: Channel, client: any MessageIOSink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(threadUpdate: thread, client: client)
         }
     }
 
-    public func on(deleteGuild guild: Guild, client: any MessageClient) {
+    public func on(deleteGuild guild: Guild, client: any MessageIOSink) {
         eventListenerBus.fire(event: .deleteGuild, with: .none) // TODO: Pass guild ID?
     }
 
-    public func on(updateGuild guild: Guild, client: any MessageClient) {
+    public func on(updateGuild guild: Guild, client: any MessageIOSink) {
         do {
             log.info("Updating guild '\(guild.name)' in message database...")
             try messageDB.insert(guild: guild)
@@ -706,7 +706,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateGuild, with: .none) // TODO: Pass guild ID?
     }
 
-    public func on(addGuildMember member: Guild.Member, client: any MessageClient) {
+    public func on(addGuildMember member: Guild.Member, client: any MessageIOSink) {
         do {
             if let guild = client.guild(for: member.guildId) {
                 log.info("Inserting member '\(member.displayName)' into message database...")
@@ -719,11 +719,11 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .addGuildMember, with: .mentions([member.user]))
     }
 
-    public func on(removeGuildMember member: Guild.Member, client: any MessageClient) {
+    public func on(removeGuildMember member: Guild.Member, client: any MessageIOSink) {
         eventListenerBus.fire(event: .removeGuildMember, with: .mentions([member.user]))
     }
 
-    public func on(updateGuildMember member: Guild.Member, client: any MessageClient) {
+    public func on(updateGuildMember member: Guild.Member, client: any MessageIOSink) {
         do {
             if let guild = client.guild(for: member.guildId) {
                 log.info("Updating member '\(member.displayName)' in message database...")
@@ -736,7 +736,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateGuildMember, with: .mentions([member.user]))
     }
 
-    public func on(createRole role: Role, on guild: Guild, client: any MessageClient) {
+    public func on(createRole role: Role, on guild: Guild, client: any MessageIOSink) {
         do {
             log.info("Inserting role '\(role.name)' on '\(guild.name)' into message database...")
             try messageDB.insert(role: role, on: guild)
@@ -747,11 +747,11 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .createRole, with: .none) // TODO: Pass role ID/role mention?
     }
 
-    public func on(deleteRole role: Role, from guild: Guild, client: any MessageClient) {
+    public func on(deleteRole role: Role, from guild: Guild, client: any MessageIOSink) {
         eventListenerBus.fire(event: .deleteRole, with: .none) // TODO: Pass role ID/role mention?
     }
 
-    public func on(updateRole role: Role, on guild: Guild, client: any MessageClient) {
+    public func on(updateRole role: Role, on guild: Guild, client: any MessageIOSink) {
         do {
             log.info("Updating role '\(role.name)' on '\(guild.name)' in message database...")
             try messageDB.insert(role: role, on: guild)
@@ -762,19 +762,19 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateRole, with: .none) // TODO: Pass role ID/role mention?
     }
 
-    public func on(connect connected: Bool, client: any MessageClient) {
+    public func on(connect connected: Bool, client: any MessageIOSink) {
         eventListenerBus.fire(event: .connect, with: .none) // TODO: Pass 'connected'?
     }
 
-    public func on(receiveVoiceStateUpdate state: VoiceState, client: any MessageClient) {
+    public func on(receiveVoiceStateUpdate state: VoiceState, client: any MessageIOSink) {
         eventListenerBus.fire(event: .receiveVoiceStateUpdate, with: .none) // TODO: Pass state?
     }
 
-    public func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any MessageClient) {
+    public func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any MessageIOSink) {
         eventListenerBus.fire(event: .handleGuildMemberChunk, with: .none) // TODO: Pass state?
     }
 
-    public func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any MessageClient) {
+    public func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any MessageIOSink) {
         do {
             log.info("Updating emojis on '\(guild.name)' in message database...")
             for emoji in emojis.values {

--- a/Sources/D2Handlers/D2Delegate.swift
+++ b/Sources/D2Handlers/D2Delegate.swift
@@ -43,7 +43,7 @@ public class D2Delegate: MessageDelegate {
         mioCommandGuildId: GuildID? = nil,
         logBuffer: LogBuffer,
         eventLoopGroup: any EventLoopGroup,
-        client: any MessageIOSink
+        client: any Sink
     ) throws {
         self.commandPrefix = commandPrefix
         self.hostInfo = hostInfo
@@ -461,7 +461,7 @@ public class D2Delegate: MessageDelegate {
         registry["help", aka: ["h"]] = HelpCommand(commandPrefix: commandPrefix, permissionManager: permissionManager)
     }
 
-    public func on(receiveReady: [String: Any], client: any MessageIOSink) {
+    public func on(receiveReady: [String: Any], client: any Sink) {
         let guildCount = client.guilds?.count ?? 0
         log.info("Received ready! \(guildCount) \("guild".pluralized(with: guildCount)) found.")
 
@@ -539,7 +539,7 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(receivePresenceUpdate presence: Presence, client: any MessageIOSink) {
+    public func on(receivePresenceUpdate presence: Presence, client: any Sink) {
         for (_, entry) in registry {
             if case let .command(command) = entry {
                 command.onReceivedUpdated(presence: presence)
@@ -554,7 +554,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .receivePresenceUpdate, with: presence.activities.first.map { RichValue.text($0.name) } ?? .none)
     }
 
-    public func on(createGuild guild: Guild, client: any MessageIOSink) {
+    public func on(createGuild guild: Guild, client: any Sink) {
         do {
             log.info("Inserting guild '\(guild.name)' into message database...")
             try messageDB.insert(guild: guild)
@@ -571,7 +571,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .createGuild, with: .none) // TODO: Provide guild ID?
     }
 
-    public func on(createMessage message: Message, client: any MessageIOSink) {
+    public func on(createMessage message: Message, client: any Sink) {
         var m = message
 
         for rewriter in messageRewriters {
@@ -605,7 +605,7 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(createInteraction interaction: Interaction, client: any MessageIOSink) {
+    public func on(createInteraction interaction: Interaction, client: any Sink) {
         for i in interactionHandlers.indices {
             if interactionHandlers[i].handle(interaction: interaction, client: client) {
                 return
@@ -613,25 +613,25 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
+    public func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
         for i in reactionHandlers.indices {
             reactionHandlers[i].handle(createdReaction: reaction, to: messageId, on: channelId, by: userId, client: client)
         }
     }
 
-    public func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
+    public func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
         for i in reactionHandlers.indices {
             reactionHandlers[i].handle(deletedReaction: reaction, from: messageId, on: channelId, by: userId, client: client)
         }
     }
 
-    public func on(removeAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageIOSink) {
+    public func on(removeAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any Sink) {
         for i in reactionHandlers.indices {
             reactionHandlers[i].handle(deletedAllReactionsFrom: messageId, on: channelId, client: client)
         }
     }
 
-    public func on(updateMessage message: Message, client: any MessageIOSink) {
+    public func on(updateMessage message: Message, client: any Sink) {
         MessageParser().parse(message: message, clientName: client.name, guild: message.guild).listenOrLogError {
             self.eventListenerBus.fire(event: .updateMessage, with: $0, context: CommandContext(
                 client: client,
@@ -645,11 +645,11 @@ public class D2Delegate: MessageDelegate {
         }
     }
 
-    public func on(disconnectWithReason reason: String, client: any MessageIOSink) {
+    public func on(disconnectWithReason reason: String, client: any Sink) {
         eventListenerBus.fire(event: .disconnectWithReason, with: .text(reason))
     }
 
-    public func on(createChannel channel: Channel, client: any MessageIOSink) {
+    public func on(createChannel channel: Channel, client: any Sink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(channelCreate: channel, client: client)
         }
@@ -657,7 +657,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .createChannel, with: .none) // TODO: Pass channel ID?
     }
 
-    public func on(deleteChannel channel: Channel, client: any MessageIOSink) {
+    public func on(deleteChannel channel: Channel, client: any Sink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(channelDelete: channel, client: client)
         }
@@ -665,7 +665,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .deleteChannel, with: .none) // TODO: Pass channel ID?
     }
 
-    public func on(updateChannel channel: Channel, client: any MessageIOSink) {
+    public func on(updateChannel channel: Channel, client: any Sink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(channelUpdate: channel, client: client)
         }
@@ -673,29 +673,29 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateChannel, with: .none) // TODO: Pass channel ID?
     }
 
-    public func on(createThread thread: Channel, client: any MessageIOSink) {
+    public func on(createThread thread: Channel, client: any Sink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(threadCreate: thread, client: client)
         }
     }
 
-    public func on(deleteThread thread: Channel, client: any MessageIOSink) {
+    public func on(deleteThread thread: Channel, client: any Sink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(threadDelete: thread, client: client)
         }
     }
 
-    public func on(updateThread thread: Channel, client: any MessageIOSink) {
+    public func on(updateThread thread: Channel, client: any Sink) {
         for i in channelHandlers.indices {
             channelHandlers[i].handle(threadUpdate: thread, client: client)
         }
     }
 
-    public func on(deleteGuild guild: Guild, client: any MessageIOSink) {
+    public func on(deleteGuild guild: Guild, client: any Sink) {
         eventListenerBus.fire(event: .deleteGuild, with: .none) // TODO: Pass guild ID?
     }
 
-    public func on(updateGuild guild: Guild, client: any MessageIOSink) {
+    public func on(updateGuild guild: Guild, client: any Sink) {
         do {
             log.info("Updating guild '\(guild.name)' in message database...")
             try messageDB.insert(guild: guild)
@@ -706,7 +706,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateGuild, with: .none) // TODO: Pass guild ID?
     }
 
-    public func on(addGuildMember member: Guild.Member, client: any MessageIOSink) {
+    public func on(addGuildMember member: Guild.Member, client: any Sink) {
         do {
             if let guild = client.guild(for: member.guildId) {
                 log.info("Inserting member '\(member.displayName)' into message database...")
@@ -719,11 +719,11 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .addGuildMember, with: .mentions([member.user]))
     }
 
-    public func on(removeGuildMember member: Guild.Member, client: any MessageIOSink) {
+    public func on(removeGuildMember member: Guild.Member, client: any Sink) {
         eventListenerBus.fire(event: .removeGuildMember, with: .mentions([member.user]))
     }
 
-    public func on(updateGuildMember member: Guild.Member, client: any MessageIOSink) {
+    public func on(updateGuildMember member: Guild.Member, client: any Sink) {
         do {
             if let guild = client.guild(for: member.guildId) {
                 log.info("Updating member '\(member.displayName)' in message database...")
@@ -736,7 +736,7 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateGuildMember, with: .mentions([member.user]))
     }
 
-    public func on(createRole role: Role, on guild: Guild, client: any MessageIOSink) {
+    public func on(createRole role: Role, on guild: Guild, client: any Sink) {
         do {
             log.info("Inserting role '\(role.name)' on '\(guild.name)' into message database...")
             try messageDB.insert(role: role, on: guild)
@@ -747,11 +747,11 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .createRole, with: .none) // TODO: Pass role ID/role mention?
     }
 
-    public func on(deleteRole role: Role, from guild: Guild, client: any MessageIOSink) {
+    public func on(deleteRole role: Role, from guild: Guild, client: any Sink) {
         eventListenerBus.fire(event: .deleteRole, with: .none) // TODO: Pass role ID/role mention?
     }
 
-    public func on(updateRole role: Role, on guild: Guild, client: any MessageIOSink) {
+    public func on(updateRole role: Role, on guild: Guild, client: any Sink) {
         do {
             log.info("Updating role '\(role.name)' on '\(guild.name)' in message database...")
             try messageDB.insert(role: role, on: guild)
@@ -762,19 +762,19 @@ public class D2Delegate: MessageDelegate {
         eventListenerBus.fire(event: .updateRole, with: .none) // TODO: Pass role ID/role mention?
     }
 
-    public func on(connect connected: Bool, client: any MessageIOSink) {
+    public func on(connect connected: Bool, client: any Sink) {
         eventListenerBus.fire(event: .connect, with: .none) // TODO: Pass 'connected'?
     }
 
-    public func on(receiveVoiceStateUpdate state: VoiceState, client: any MessageIOSink) {
+    public func on(receiveVoiceStateUpdate state: VoiceState, client: any Sink) {
         eventListenerBus.fire(event: .receiveVoiceStateUpdate, with: .none) // TODO: Pass state?
     }
 
-    public func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any MessageIOSink) {
+    public func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any Sink) {
         eventListenerBus.fire(event: .handleGuildMemberChunk, with: .none) // TODO: Pass state?
     }
 
-    public func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any MessageIOSink) {
+    public func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any Sink) {
         do {
             log.info("Updating emojis on '\(guild.name)' in message database...")
             for emoji in emojis.values {

--- a/Sources/D2Handlers/D2Receiver.swift
+++ b/Sources/D2Handlers/D2Receiver.swift
@@ -11,7 +11,7 @@ import protocol NIO.EventLoopGroup
 
 fileprivate let log = Logger(label: "D2Handlers.D2Receiver")
 
-/// The main event handler by D2.
+/// D2's main event handler.
 public class D2Receiver: Receiver {
     private let commandPrefix: String
     private let hostInfo: HostInfo

--- a/Sources/D2Handlers/D2Receiver.swift
+++ b/Sources/D2Handlers/D2Receiver.swift
@@ -9,10 +9,10 @@ import D2Permissions
 import class NIO.MultiThreadedEventLoopGroup
 import protocol NIO.EventLoopGroup
 
-fileprivate let log = Logger(label: "D2Handlers.D2Delegate")
+fileprivate let log = Logger(label: "D2Handlers.D2Receiver")
 
-/// A client delegate that dispatches commands.
-public class D2Delegate: MessageDelegate {
+/// The main event handler by D2.
+public class D2Receiver: Receiver {
     private let commandPrefix: String
     private let hostInfo: HostInfo
     private let initialPresence: String?

--- a/Sources/D2Handlers/DemoDelegate.swift
+++ b/Sources/D2Handlers/DemoDelegate.swift
@@ -4,7 +4,7 @@ import Logging
 fileprivate let log = Logger(label: "D2Handlers.DemoDelegate")
 
 public class DemoDelegate: MessageDelegate {
-    public func on(createMessage message: Message, client: any MessageClient) {
+    public func on(createMessage message: Message, client: any MessageIOSink) {
         log.info("Created message \(message.content)")
     }
 }

--- a/Sources/D2Handlers/DemoDelegate.swift
+++ b/Sources/D2Handlers/DemoDelegate.swift
@@ -4,7 +4,7 @@ import Logging
 fileprivate let log = Logger(label: "D2Handlers.DemoDelegate")
 
 public class DemoDelegate: MessageDelegate {
-    public func on(createMessage message: Message, client: any MessageIOSink) {
+    public func on(createMessage message: Message, client: any Sink) {
         log.info("Created message \(message.content)")
     }
 }

--- a/Sources/D2Handlers/DemoDelegate.swift
+++ b/Sources/D2Handlers/DemoDelegate.swift
@@ -4,7 +4,7 @@ import Logging
 fileprivate let log = Logger(label: "D2Handlers.DemoDelegate")
 
 public class DemoDelegate: MessageDelegate {
-    public func on(createMessage message: Message, client: any Sink) {
+    public func on(createMessage message: Message, sink: any Sink) {
         log.info("Created message \(message.content)")
     }
 }

--- a/Sources/D2Handlers/DemoReceiver.swift
+++ b/Sources/D2Handlers/DemoReceiver.swift
@@ -1,9 +1,9 @@
 import D2MessageIO
 import Logging
 
-fileprivate let log = Logger(label: "D2Handlers.DemoDelegate")
+fileprivate let log = Logger(label: "D2Handlers.DemoReceiver")
 
-public class DemoDelegate: MessageDelegate {
+public class DemoReceiver: Receiver {
     public func on(createMessage message: Message, sink: any Sink) {
         log.info("Created message \(message.content)")
     }

--- a/Sources/D2Handlers/channel/handler/ChannelHandler.swift
+++ b/Sources/D2Handlers/channel/handler/ChannelHandler.swift
@@ -2,30 +2,30 @@ import D2MessageIO
 
 /// Anything that handles channel updates from Discord.
 public protocol ChannelHandler {
-    mutating func handle(channelCreate channel: Channel, client: any MessageClient)
+    mutating func handle(channelCreate channel: Channel, client: any MessageIOSink)
 
-    mutating func handle(channelUpdate channel: Channel, client: any MessageClient)
+    mutating func handle(channelUpdate channel: Channel, client: any MessageIOSink)
 
-    mutating func handle(channelDelete channel: Channel, client: any MessageClient)
+    mutating func handle(channelDelete channel: Channel, client: any MessageIOSink)
 
-    mutating func handle(threadCreate thread: Channel, client: any MessageClient)
+    mutating func handle(threadCreate thread: Channel, client: any MessageIOSink)
 
-    mutating func handle(threadUpdate thread: Channel, client: any MessageClient)
+    mutating func handle(threadUpdate thread: Channel, client: any MessageIOSink)
 
-    mutating func handle(threadDelete thread: Channel, client: any MessageClient)
+    mutating func handle(threadDelete thread: Channel, client: any MessageIOSink)
 }
 
 public extension ChannelHandler {
-    func handle(channelCreate channel: Channel, client: any MessageClient) {}
+    func handle(channelCreate channel: Channel, client: any MessageIOSink) {}
 
-    func handle(channelUpdate channel: Channel, client: any MessageClient) {}
+    func handle(channelUpdate channel: Channel, client: any MessageIOSink) {}
 
-    func handle(channelDelete channel: Channel, client: any MessageClient) {}
+    func handle(channelDelete channel: Channel, client: any MessageIOSink) {}
 
-    func handle(threadCreate thread: Channel, client: any MessageClient) {}
+    func handle(threadCreate thread: Channel, client: any MessageIOSink) {}
 
-    func handle(threadUpdate thread: Channel, client: any MessageClient) {}
+    func handle(threadUpdate thread: Channel, client: any MessageIOSink) {}
 
-    func handle(threadDelete thread: Channel, client: any MessageClient) {}
+    func handle(threadDelete thread: Channel, client: any MessageIOSink) {}
 }
 

--- a/Sources/D2Handlers/channel/handler/ChannelHandler.swift
+++ b/Sources/D2Handlers/channel/handler/ChannelHandler.swift
@@ -2,30 +2,30 @@ import D2MessageIO
 
 /// Anything that handles channel updates from Discord.
 public protocol ChannelHandler {
-    mutating func handle(channelCreate channel: Channel, client: any Sink)
+    mutating func handle(channelCreate channel: Channel, sink: any Sink)
 
-    mutating func handle(channelUpdate channel: Channel, client: any Sink)
+    mutating func handle(channelUpdate channel: Channel, sink: any Sink)
 
-    mutating func handle(channelDelete channel: Channel, client: any Sink)
+    mutating func handle(channelDelete channel: Channel, sink: any Sink)
 
-    mutating func handle(threadCreate thread: Channel, client: any Sink)
+    mutating func handle(threadCreate thread: Channel, sink: any Sink)
 
-    mutating func handle(threadUpdate thread: Channel, client: any Sink)
+    mutating func handle(threadUpdate thread: Channel, sink: any Sink)
 
-    mutating func handle(threadDelete thread: Channel, client: any Sink)
+    mutating func handle(threadDelete thread: Channel, sink: any Sink)
 }
 
 public extension ChannelHandler {
-    func handle(channelCreate channel: Channel, client: any Sink) {}
+    func handle(channelCreate channel: Channel, sink: any Sink) {}
 
-    func handle(channelUpdate channel: Channel, client: any Sink) {}
+    func handle(channelUpdate channel: Channel, sink: any Sink) {}
 
-    func handle(channelDelete channel: Channel, client: any Sink) {}
+    func handle(channelDelete channel: Channel, sink: any Sink) {}
 
-    func handle(threadCreate thread: Channel, client: any Sink) {}
+    func handle(threadCreate thread: Channel, sink: any Sink) {}
 
-    func handle(threadUpdate thread: Channel, client: any Sink) {}
+    func handle(threadUpdate thread: Channel, sink: any Sink) {}
 
-    func handle(threadDelete thread: Channel, client: any Sink) {}
+    func handle(threadDelete thread: Channel, sink: any Sink) {}
 }
 

--- a/Sources/D2Handlers/channel/handler/ChannelHandler.swift
+++ b/Sources/D2Handlers/channel/handler/ChannelHandler.swift
@@ -2,30 +2,30 @@ import D2MessageIO
 
 /// Anything that handles channel updates from Discord.
 public protocol ChannelHandler {
-    mutating func handle(channelCreate channel: Channel, client: any MessageIOSink)
+    mutating func handle(channelCreate channel: Channel, client: any Sink)
 
-    mutating func handle(channelUpdate channel: Channel, client: any MessageIOSink)
+    mutating func handle(channelUpdate channel: Channel, client: any Sink)
 
-    mutating func handle(channelDelete channel: Channel, client: any MessageIOSink)
+    mutating func handle(channelDelete channel: Channel, client: any Sink)
 
-    mutating func handle(threadCreate thread: Channel, client: any MessageIOSink)
+    mutating func handle(threadCreate thread: Channel, client: any Sink)
 
-    mutating func handle(threadUpdate thread: Channel, client: any MessageIOSink)
+    mutating func handle(threadUpdate thread: Channel, client: any Sink)
 
-    mutating func handle(threadDelete thread: Channel, client: any MessageIOSink)
+    mutating func handle(threadDelete thread: Channel, client: any Sink)
 }
 
 public extension ChannelHandler {
-    func handle(channelCreate channel: Channel, client: any MessageIOSink) {}
+    func handle(channelCreate channel: Channel, client: any Sink) {}
 
-    func handle(channelUpdate channel: Channel, client: any MessageIOSink) {}
+    func handle(channelUpdate channel: Channel, client: any Sink) {}
 
-    func handle(channelDelete channel: Channel, client: any MessageIOSink) {}
+    func handle(channelDelete channel: Channel, client: any Sink) {}
 
-    func handle(threadCreate thread: Channel, client: any MessageIOSink) {}
+    func handle(threadCreate thread: Channel, client: any Sink) {}
 
-    func handle(threadUpdate thread: Channel, client: any MessageIOSink) {}
+    func handle(threadUpdate thread: Channel, client: any Sink) {}
 
-    func handle(threadDelete thread: Channel, client: any MessageIOSink) {}
+    func handle(threadDelete thread: Channel, client: any Sink) {}
 }
 

--- a/Sources/D2Handlers/channel/handler/MessageDatabaseChannelHandler.swift
+++ b/Sources/D2Handlers/channel/handler/MessageDatabaseChannelHandler.swift
@@ -11,9 +11,9 @@ public struct MessageDatabaseChannelHandler: ChannelHandler {
         self.messageDB = messageDB
     }
 
-    private func update(channel: Channel, on eventName: String, client: any Sink) {
+    private func update(channel: Channel, on eventName: String, sink: any Sink) {
         do {
-            if let guild = client.guildForChannel(channel.id) {
+            if let guild = sink.guildForChannel(channel.id) {
                 log.info("Updating channel '\(channel.name)' on \(eventName) into message database...")
                 try messageDB.insert(channel: channel, on: guild)
             }
@@ -22,19 +22,19 @@ public struct MessageDatabaseChannelHandler: ChannelHandler {
         }
     }
 
-    public func handle(channelCreate channel: Channel, client: any Sink) {
-        update(channel: channel, on: "creation", client: client)
+    public func handle(channelCreate channel: Channel, sink: any Sink) {
+        update(channel: channel, on: "creation", sink: sink)
     }
 
-    public func handle(channelUpdate channel: Channel, client: any Sink) {
-        update(channel: channel, on: "update", client: client)
+    public func handle(channelUpdate channel: Channel, sink: any Sink) {
+        update(channel: channel, on: "update", sink: sink)
     }
 
-    public func handle(threadCreate thread: Channel, client: any Sink) {
-        update(channel: thread, on: "thread creation", client: client)
+    public func handle(threadCreate thread: Channel, sink: any Sink) {
+        update(channel: thread, on: "thread creation", sink: sink)
     }
 
-    public func handle(threadUpdate thread: Channel, client: any Sink) {
-        update(channel: thread, on: "thread update", client: client)
+    public func handle(threadUpdate thread: Channel, sink: any Sink) {
+        update(channel: thread, on: "thread update", sink: sink)
     }
 }

--- a/Sources/D2Handlers/channel/handler/MessageDatabaseChannelHandler.swift
+++ b/Sources/D2Handlers/channel/handler/MessageDatabaseChannelHandler.swift
@@ -11,7 +11,7 @@ public struct MessageDatabaseChannelHandler: ChannelHandler {
         self.messageDB = messageDB
     }
 
-    private func update(channel: Channel, on eventName: String, client: any MessageClient) {
+    private func update(channel: Channel, on eventName: String, client: any MessageIOSink) {
         do {
             if let guild = client.guildForChannel(channel.id) {
                 log.info("Updating channel '\(channel.name)' on \(eventName) into message database...")
@@ -22,19 +22,19 @@ public struct MessageDatabaseChannelHandler: ChannelHandler {
         }
     }
 
-    public func handle(channelCreate channel: Channel, client: any MessageClient) {
+    public func handle(channelCreate channel: Channel, client: any MessageIOSink) {
         update(channel: channel, on: "creation", client: client)
     }
 
-    public func handle(channelUpdate channel: Channel, client: any MessageClient) {
+    public func handle(channelUpdate channel: Channel, client: any MessageIOSink) {
         update(channel: channel, on: "update", client: client)
     }
 
-    public func handle(threadCreate thread: Channel, client: any MessageClient) {
+    public func handle(threadCreate thread: Channel, client: any MessageIOSink) {
         update(channel: thread, on: "thread creation", client: client)
     }
 
-    public func handle(threadUpdate thread: Channel, client: any MessageClient) {
+    public func handle(threadUpdate thread: Channel, client: any MessageIOSink) {
         update(channel: thread, on: "thread update", client: client)
     }
 }

--- a/Sources/D2Handlers/channel/handler/MessageDatabaseChannelHandler.swift
+++ b/Sources/D2Handlers/channel/handler/MessageDatabaseChannelHandler.swift
@@ -11,7 +11,7 @@ public struct MessageDatabaseChannelHandler: ChannelHandler {
         self.messageDB = messageDB
     }
 
-    private func update(channel: Channel, on eventName: String, client: any MessageIOSink) {
+    private func update(channel: Channel, on eventName: String, client: any Sink) {
         do {
             if let guild = client.guildForChannel(channel.id) {
                 log.info("Updating channel '\(channel.name)' on \(eventName) into message database...")
@@ -22,19 +22,19 @@ public struct MessageDatabaseChannelHandler: ChannelHandler {
         }
     }
 
-    public func handle(channelCreate channel: Channel, client: any MessageIOSink) {
+    public func handle(channelCreate channel: Channel, client: any Sink) {
         update(channel: channel, on: "creation", client: client)
     }
 
-    public func handle(channelUpdate channel: Channel, client: any MessageIOSink) {
+    public func handle(channelUpdate channel: Channel, client: any Sink) {
         update(channel: channel, on: "update", client: client)
     }
 
-    public func handle(threadCreate thread: Channel, client: any MessageIOSink) {
+    public func handle(threadCreate thread: Channel, client: any Sink) {
         update(channel: thread, on: "thread creation", client: client)
     }
 
-    public func handle(threadUpdate thread: Channel, client: any MessageIOSink) {
+    public func handle(threadUpdate thread: Channel, client: any Sink) {
         update(channel: thread, on: "thread update", client: client)
     }
 }

--- a/Sources/D2Handlers/channel/handler/ThreadKeepaliveHandler.swift
+++ b/Sources/D2Handlers/channel/handler/ThreadKeepaliveHandler.swift
@@ -12,7 +12,7 @@ public struct ThreadKeepaliveHandler: ChannelHandler {
         self._config = _config
     }
 
-    public func handle(threadUpdate thread: Channel, client: any MessageIOSink) {
+    public func handle(threadUpdate thread: Channel, client: any Sink) {
         log.info("Thread \(thread.name) has archival status: \(thread.threadMetadata?.archived ?? false)")
 
         let archived = thread.threadMetadata?.archived ?? false

--- a/Sources/D2Handlers/channel/handler/ThreadKeepaliveHandler.swift
+++ b/Sources/D2Handlers/channel/handler/ThreadKeepaliveHandler.swift
@@ -12,7 +12,7 @@ public struct ThreadKeepaliveHandler: ChannelHandler {
         self._config = _config
     }
 
-    public func handle(threadUpdate thread: Channel, client: any Sink) {
+    public func handle(threadUpdate thread: Channel, sink: any Sink) {
         log.info("Thread \(thread.name) has archival status: \(thread.threadMetadata?.archived ?? false)")
 
         let archived = thread.threadMetadata?.archived ?? false
@@ -33,7 +33,7 @@ public struct ThreadKeepaliveHandler: ChannelHandler {
             }
 
             log.info("Unarchiving '\(thread.name)'")
-            client.modifyChannel(thread.id, with: .init(archived: false))
+            sink.modifyChannel(thread.id, with: .init(archived: false))
         }
     }
 }

--- a/Sources/D2Handlers/channel/handler/ThreadKeepaliveHandler.swift
+++ b/Sources/D2Handlers/channel/handler/ThreadKeepaliveHandler.swift
@@ -12,7 +12,7 @@ public struct ThreadKeepaliveHandler: ChannelHandler {
         self._config = _config
     }
 
-    public func handle(threadUpdate thread: Channel, client: any MessageClient) {
+    public func handle(threadUpdate thread: Channel, client: any MessageIOSink) {
         log.info("Thread \(thread.name) has archival status: \(thread.threadMetadata?.archived ?? false)")
 
         let archived = thread.threadMetadata?.archived ?? false

--- a/Sources/D2Handlers/interaction/handler/InteractionHandler.swift
+++ b/Sources/D2Handlers/interaction/handler/InteractionHandler.swift
@@ -2,9 +2,9 @@ import D2MessageIO
 
 /// Anything that handles interactions from Discord.
 public protocol InteractionHandler {
-    mutating func handle(interaction: Interaction, client: any MessageIOSink) -> Bool
+    mutating func handle(interaction: Interaction, client: any Sink) -> Bool
 }
 
 extension InteractionHandler {
-    func handle(interaction: Interaction, client: any MessageIOSink) -> Bool { false }
+    func handle(interaction: Interaction, client: any Sink) -> Bool { false }
 }

--- a/Sources/D2Handlers/interaction/handler/InteractionHandler.swift
+++ b/Sources/D2Handlers/interaction/handler/InteractionHandler.swift
@@ -2,9 +2,9 @@ import D2MessageIO
 
 /// Anything that handles interactions from Discord.
 public protocol InteractionHandler {
-    mutating func handle(interaction: Interaction, client: any Sink) -> Bool
+    mutating func handle(interaction: Interaction, sink: any Sink) -> Bool
 }
 
 extension InteractionHandler {
-    func handle(interaction: Interaction, client: any Sink) -> Bool { false }
+    func handle(interaction: Interaction, sink: any Sink) -> Bool { false }
 }

--- a/Sources/D2Handlers/interaction/handler/InteractionHandler.swift
+++ b/Sources/D2Handlers/interaction/handler/InteractionHandler.swift
@@ -2,9 +2,9 @@ import D2MessageIO
 
 /// Anything that handles interactions from Discord.
 public protocol InteractionHandler {
-    mutating func handle(interaction: Interaction, client: any MessageClient) -> Bool
+    mutating func handle(interaction: Interaction, client: any MessageIOSink) -> Bool
 }
 
 extension InteractionHandler {
-    func handle(interaction: Interaction, client: any MessageClient) -> Bool { false }
+    func handle(interaction: Interaction, client: any MessageIOSink) -> Bool { false }
 }

--- a/Sources/D2Handlers/interaction/handler/MIOCommandInteractionHandler.swift
+++ b/Sources/D2Handlers/interaction/handler/MIOCommandInteractionHandler.swift
@@ -16,7 +16,7 @@ public struct MIOCommandInteractionHandler: InteractionHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(interaction: Interaction, client: any MessageIOSink) -> Bool {
+    public func handle(interaction: Interaction, client: any Sink) -> Bool {
         guard
             interaction.type == .mioCommand,
             let data = interaction.data,

--- a/Sources/D2Handlers/interaction/handler/MIOCommandInteractionHandler.swift
+++ b/Sources/D2Handlers/interaction/handler/MIOCommandInteractionHandler.swift
@@ -16,7 +16,7 @@ public struct MIOCommandInteractionHandler: InteractionHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(interaction: Interaction, client: any Sink) -> Bool {
+    public func handle(interaction: Interaction, sink: any Sink) -> Bool {
         guard
             interaction.type == .mioCommand,
             let data = interaction.data,
@@ -25,13 +25,13 @@ public struct MIOCommandInteractionHandler: InteractionHandler {
         let content = invocation.options.compactMap { $0.value as? String }.joined(separator: " ")
         let input = RichValue.text(content)
         let context = CommandContext(
-            client: client,
+            sink: sink,
             registry: registry,
             message: Message(
                 content: content,
                 author: interaction.member?.user,
                 channelId: interaction.channelId,
-                guild: interaction.guildId.flatMap(client.guild(for:)),
+                guild: interaction.guildId.flatMap(sink.guild(for:)),
                 guildMember: interaction.member
             ),
             commandPrefix: "/", // TODO: Find a more elegant solution than hardcoding the slash

--- a/Sources/D2Handlers/interaction/handler/MIOCommandInteractionHandler.swift
+++ b/Sources/D2Handlers/interaction/handler/MIOCommandInteractionHandler.swift
@@ -16,7 +16,7 @@ public struct MIOCommandInteractionHandler: InteractionHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(interaction: Interaction, client: any MessageClient) -> Bool {
+    public func handle(interaction: Interaction, client: any MessageIOSink) -> Bool {
         guard
             interaction.type == .mioCommand,
             let data = interaction.data,

--- a/Sources/D2Handlers/interaction/handler/SubscriptionInteractionHandler.swift
+++ b/Sources/D2Handlers/interaction/handler/SubscriptionInteractionHandler.swift
@@ -17,7 +17,7 @@ public struct SubscriptionInteractionHandler: InteractionHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(interaction: Interaction, client: any MessageClient) -> Bool {
+    public func handle(interaction: Interaction, client: any MessageIOSink) -> Bool {
         guard
             interaction.type == .messageComponent,
             let customId = interaction.data?.customId,

--- a/Sources/D2Handlers/interaction/handler/SubscriptionInteractionHandler.swift
+++ b/Sources/D2Handlers/interaction/handler/SubscriptionInteractionHandler.swift
@@ -17,17 +17,17 @@ public struct SubscriptionInteractionHandler: InteractionHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(interaction: Interaction, client: any Sink) -> Bool {
+    public func handle(interaction: Interaction, sink: any Sink) -> Bool {
         guard
             interaction.type == .messageComponent,
             let customId = interaction.data?.customId,
             let channelId = interaction.channelId,
             let member = interaction.member else { return false }
-        let message = interaction.message ?? Message(content: "Dummy", channelId: channelId, id: MessageID("", clientName: client.name))
+        let message = interaction.message ?? Message(content: "Dummy", channelId: channelId, id: MessageID("", clientName: sink.name))
         let user = member.user
         manager.notifySubscriptions(on: channelId, isBot: user.bot) {
             let context = CommandContext(
-                client: client,
+                sink: sink,
                 registry: registry,
                 message: message,
                 commandPrefix: commandPrefix,

--- a/Sources/D2Handlers/interaction/handler/SubscriptionInteractionHandler.swift
+++ b/Sources/D2Handlers/interaction/handler/SubscriptionInteractionHandler.swift
@@ -17,7 +17,7 @@ public struct SubscriptionInteractionHandler: InteractionHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(interaction: Interaction, client: any MessageIOSink) -> Bool {
+    public func handle(interaction: Interaction, client: any Sink) -> Bool {
         guard
             interaction.type == .messageComponent,
             let customId = interaction.data?.customId,

--- a/Sources/D2Handlers/message/handler/CommandHandler.swift
+++ b/Sources/D2Handlers/message/handler/CommandHandler.swift
@@ -89,7 +89,7 @@ public class CommandHandler: MessageHandler {
         self.pipeSeparator = pipeSeparator
     }
 
-    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handle(message: Message, from client: any Sink) -> Bool {
         guard message.content.starts(with: commandPrefix),
             !message.dm || (message.author.map { permissionManager.user($0, hasPermission: .vip) } ?? false),
             let channelId = message.channelId else { return false }
@@ -174,7 +174,7 @@ public class CommandHandler: MessageHandler {
         return true
     }
 
-    private func constructPipe(rawPipeCommand: String, message: Message, client: any MessageIOSink) -> [PipeComponent]? {
+    private func constructPipe(rawPipeCommand: String, message: Message, client: any Sink) -> [PipeComponent]? {
         guard let channelId = message.channelId, let author = message.author else { return nil }
         let isBot = author.bot
         var pipe = [PipeComponent]()

--- a/Sources/D2Handlers/message/handler/CommandHandler.swift
+++ b/Sources/D2Handlers/message/handler/CommandHandler.swift
@@ -89,7 +89,7 @@ public class CommandHandler: MessageHandler {
         self.pipeSeparator = pipeSeparator
     }
 
-    public func handle(message: Message, from client: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) -> Bool {
         guard message.content.starts(with: commandPrefix),
             !message.dm || (message.author.map { permissionManager.user($0, hasPermission: .vip) } ?? false),
             let channelId = message.channelId else { return false }
@@ -98,7 +98,7 @@ public class CommandHandler: MessageHandler {
             return false
         }
         guard currentlyRunningCommands < maxConcurrentlyRunningCommands || unconditionallyAllowedCommands.contains(where: { message.content.starts(with: "\(commandPrefix)\($0)") }) else {
-            client.sendMessage("Too many concurrent command invocations, please wait for one to finish!", to: channelId)
+            sink.sendMessage("Too many concurrent command invocations, please wait for one to finish!", to: channelId)
             log.notice("Command invocation not processed, since max concurrent operation count was reached")
             return false
         }
@@ -107,19 +107,19 @@ public class CommandHandler: MessageHandler {
 
         // Precedence: Chain < Pipe
         for rawPipeCommand in slicedMessage.splitPreservingQuotes(by: chainSeparator, omitQuotes: false, omitBackslashes: false) {
-            if let pipe = constructPipe(rawPipeCommand: rawPipeCommand, message: message, client: client) {
+            if let pipe = constructPipe(rawPipeCommand: rawPipeCommand, message: message, sink: sink) {
                 guard permissionManager.user(author, hasPermission: .admin) || (pipe.count <= maxPipeLengthForUsers) else {
-                    client.sendMessage("Your pipe is too long.", to: channelId)
+                    sink.sendMessage("Your pipe is too long.", to: channelId)
                     log.notice("Too long pipe")
                     return true
                 }
 
                 // Ensure that all commands are available on the current platform
-                let platform = client.name
+                let platform = sink.name
                 for component in pipe {
                     if let availability = component.command.info.platformAvailability {
                         guard availability.contains(platform) else {
-                            client.sendMessage("Sorry, the command `\(component.name)` is unavailable on your platform (`\(platform)`). It is supported on: \(availability.map { "`\($0)`" }.joined(separator: ", "))", to: channelId)
+                            sink.sendMessage("Sorry, the command `\(component.name)` is unavailable on your platform (`\(platform)`). It is supported on: \(availability.map { "`\($0)`" }.joined(separator: ", "))", to: channelId)
                             log.notice("\(component.name) is unavailable on \(platform)")
                             return true
                         }
@@ -132,7 +132,7 @@ public class CommandHandler: MessageHandler {
                     pipeSink.output = MessageIOOutput(context: pipeSink.context) { sentMessages in
                         for sent in sentMessages {
                             sinkCommand.onSuccessfullySent(context: CommandContext(
-                                client: client,
+                                sink: sink,
                                 registry: self.registry,
                                 message: sent,
                                 commandPrefix: self.commandPrefix,
@@ -155,7 +155,7 @@ public class CommandHandler: MessageHandler {
                     self.currentlyRunningCommands += 1
                     log.debug("Currently running \(self.currentlyRunningCommands) commands")
 
-                    self.msgParser.parse(pipeSource.args, message: message, clientName: client.name, guild: pipeSource.context.guild).listenOrLogError { input in
+                    self.msgParser.parse(pipeSource.args, message: message, clientName: sink.name, guild: pipeSource.context.guild).listenOrLogError { input in
                         // Execute the pipe
                         let runner = RunnablePipe(pipeSource: pipeSource, input: input)
                         runner.run()
@@ -174,7 +174,7 @@ public class CommandHandler: MessageHandler {
         return true
     }
 
-    private func constructPipe(rawPipeCommand: String, message: Message, client: any Sink) -> [PipeComponent]? {
+    private func constructPipe(rawPipeCommand: String, message: Message, sink: any Sink) -> [PipeComponent]? {
         guard let channelId = message.channelId, let author = message.author else { return nil }
         let isBot = author.bot
         var pipe = [PipeComponent]()
@@ -196,7 +196,7 @@ public class CommandHandler: MessageHandler {
                         log.debug("Appending '\(name)' to pipe")
 
                         let context = CommandContext(
-                            client: client,
+                            sink: sink,
                             registry: registry,
                             message: message,
                             commandPrefix: commandPrefix,
@@ -212,7 +212,7 @@ public class CommandHandler: MessageHandler {
                         }
                     } else {
                         log.notice("Rejected '\(name)' by \(author.displayTag) due to insufficient permissions")
-                        client.sendMessage("Sorry, you are not permitted to execute `\(name)`.", to: channelId)
+                        sink.sendMessage("Sorry, you are not permitted to execute `\(name)`.", to: channelId)
                         return nil
                     }
 
@@ -221,7 +221,7 @@ public class CommandHandler: MessageHandler {
                     log.notice("Did not recognize command '\(name)'")
                     if !isBot {
                         let alternative = registry.map { $0.0 }.min(by: ascendingComparator { $0.levenshteinDistance(to: name) })
-                        client.sendMessage("Sorry, I do not know the command `\(name)`.\(alternative.map { " Did you mean `\($0)`?" } ?? "")", to: channelId)
+                        sink.sendMessage("Sorry, I do not know the command `\(name)`.\(alternative.map { " Did you mean `\($0)`?" } ?? "")", to: channelId)
                     }
                     return nil
                 }

--- a/Sources/D2Handlers/message/handler/CommandHandler.swift
+++ b/Sources/D2Handlers/message/handler/CommandHandler.swift
@@ -89,7 +89,7 @@ public class CommandHandler: MessageHandler {
         self.pipeSeparator = pipeSeparator
     }
 
-    public func handle(message: Message, from client: any MessageClient) -> Bool {
+    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
         guard message.content.starts(with: commandPrefix),
             !message.dm || (message.author.map { permissionManager.user($0, hasPermission: .vip) } ?? false),
             let channelId = message.channelId else { return false }
@@ -174,7 +174,7 @@ public class CommandHandler: MessageHandler {
         return true
     }
 
-    private func constructPipe(rawPipeCommand: String, message: Message, client: any MessageClient) -> [PipeComponent]? {
+    private func constructPipe(rawPipeCommand: String, message: Message, client: any MessageIOSink) -> [PipeComponent]? {
         guard let channelId = message.channelId, let author = message.author else { return nil }
         let isBot = author.bot
         var pipe = [PipeComponent]()

--- a/Sources/D2Handlers/message/handler/CountToNHandler.swift
+++ b/Sources/D2Handlers/message/handler/CountToNHandler.swift
@@ -5,7 +5,7 @@ import Utils
 fileprivate let countToNPattern = try! Regex(from: "count\\s+to\\s+(\\d+)")
 
 public struct CountToNHandler: MessageHandler {
-    public func handle(message: Message, from client: any MessageClient) -> Bool {
+    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
         if let parsed = countToNPattern.firstGroups(in: message.content.lowercased()), let n = UInt(parsed[1]), n <= 300, let channelId = message.channelId {
             client.sendMessage(Message(content: "Here you go: \((1...n).map(String.init).joined(separator: ", "))"), to: channelId)
             return true

--- a/Sources/D2Handlers/message/handler/CountToNHandler.swift
+++ b/Sources/D2Handlers/message/handler/CountToNHandler.swift
@@ -5,7 +5,7 @@ import Utils
 fileprivate let countToNPattern = try! Regex(from: "count\\s+to\\s+(\\d+)")
 
 public struct CountToNHandler: MessageHandler {
-    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handle(message: Message, from client: any Sink) -> Bool {
         if let parsed = countToNPattern.firstGroups(in: message.content.lowercased()), let n = UInt(parsed[1]), n <= 300, let channelId = message.channelId {
             client.sendMessage(Message(content: "Here you go: \((1...n).map(String.init).joined(separator: ", "))"), to: channelId)
             return true

--- a/Sources/D2Handlers/message/handler/CountToNHandler.swift
+++ b/Sources/D2Handlers/message/handler/CountToNHandler.swift
@@ -5,9 +5,9 @@ import Utils
 fileprivate let countToNPattern = try! Regex(from: "count\\s+to\\s+(\\d+)")
 
 public struct CountToNHandler: MessageHandler {
-    public func handle(message: Message, from client: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) -> Bool {
         if let parsed = countToNPattern.firstGroups(in: message.content.lowercased()), let n = UInt(parsed[1]), n <= 300, let channelId = message.channelId {
-            client.sendMessage(Message(content: "Here you go: \((1...n).map(String.init).joined(separator: ", "))"), to: channelId)
+            sink.sendMessage(Message(content: "Here you go: \((1...n).map(String.init).joined(separator: ", "))"), to: channelId)
             return true
         }
         return false

--- a/Sources/D2Handlers/message/handler/HaikuHandler.swift
+++ b/Sources/D2Handlers/message/handler/HaikuHandler.swift
@@ -22,7 +22,7 @@ public struct HaikuHandler: MessageHandler {
         self.inventoryManager = inventoryManager
     }
 
-    public func handle(message: Message, from client: any MessageClient) -> Bool {
+    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
         if let channelId = message.channelId,
             configuration.enabledChannelIds.contains(channelId),
             let author = message.guildMember,

--- a/Sources/D2Handlers/message/handler/HaikuHandler.swift
+++ b/Sources/D2Handlers/message/handler/HaikuHandler.swift
@@ -22,7 +22,7 @@ public struct HaikuHandler: MessageHandler {
         self.inventoryManager = inventoryManager
     }
 
-    public func handle(message: Message, from client: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) -> Bool {
         if let channelId = message.channelId,
             configuration.enabledChannelIds.contains(channelId),
             let author = message.guildMember,
@@ -38,7 +38,7 @@ public struct HaikuHandler: MessageHandler {
             )
             inventoryManager[author.user].append(item: item, to: "Haikus")
 
-            client.sendMessage(Message(embed: Embed(
+            sink.sendMessage(Message(embed: Embed(
                 title: "A Haiku by `\(author.displayName)`",
                 description: haiku.joined(separator: "\n")
             )), to: channelId)

--- a/Sources/D2Handlers/message/handler/HaikuHandler.swift
+++ b/Sources/D2Handlers/message/handler/HaikuHandler.swift
@@ -22,7 +22,7 @@ public struct HaikuHandler: MessageHandler {
         self.inventoryManager = inventoryManager
     }
 
-    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handle(message: Message, from client: any Sink) -> Bool {
         if let channelId = message.channelId,
             configuration.enabledChannelIds.contains(channelId),
             let author = message.guildMember,

--- a/Sources/D2Handlers/message/handler/LuckyNumberHandler.swift
+++ b/Sources/D2Handlers/message/handler/LuckyNumberHandler.swift
@@ -12,12 +12,12 @@ public struct LuckyNumberHandler: MessageHandler {
         self.minimumNumberCount = minimumNumberCount
     }
 
-    public func handle(message: Message, from client: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) -> Bool {
         if let channelId = message.channelId {
             let numbers = numberPattern.allGroups(in: message.content).compactMap { Int($0[0]) }
             let sum = numbers.reduce(0, +)
             if sum == luckyNumber && numbers.count >= minimumNumberCount {
-                client.sendMessage(
+                sink.sendMessage(
                     """
                     All the numbers in your message added up to \(luckyNumber). Congrats!
                     ```

--- a/Sources/D2Handlers/message/handler/LuckyNumberHandler.swift
+++ b/Sources/D2Handlers/message/handler/LuckyNumberHandler.swift
@@ -12,7 +12,7 @@ public struct LuckyNumberHandler: MessageHandler {
         self.minimumNumberCount = minimumNumberCount
     }
 
-    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handle(message: Message, from client: any Sink) -> Bool {
         if let channelId = message.channelId {
             let numbers = numberPattern.allGroups(in: message.content).compactMap { Int($0[0]) }
             let sum = numbers.reduce(0, +)

--- a/Sources/D2Handlers/message/handler/LuckyNumberHandler.swift
+++ b/Sources/D2Handlers/message/handler/LuckyNumberHandler.swift
@@ -12,7 +12,7 @@ public struct LuckyNumberHandler: MessageHandler {
         self.minimumNumberCount = minimumNumberCount
     }
 
-    public func handle(message: Message, from client: any MessageClient) -> Bool {
+    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
         if let channelId = message.channelId {
             let numbers = numberPattern.allGroups(in: message.content).compactMap { Int($0[0]) }
             let sum = numbers.reduce(0, +)

--- a/Sources/D2Handlers/message/handler/MentionD2Handler.swift
+++ b/Sources/D2Handlers/message/handler/MentionD2Handler.swift
@@ -13,8 +13,8 @@ public struct MentionD2Handler: MessageHandler {
         self.conversator = conversator
     }
 
-    public func handleRaw(message: Message, from client: any Sink) -> Bool {
-        if let me = client.me,
+    public func handleRaw(message: Message, sink: any Sink) -> Bool {
+        if let me = sink.me,
             !message.mentionEveryone,
             message.mentions(user: me),
             let messageId = message.id,
@@ -22,9 +22,9 @@ public struct MentionD2Handler: MessageHandler {
             let channelId = message.channelId {
             queue.async {
                 if let answer = try? conversator.answer(input: mentionPattern.replace(in: message.content, with: ""), on: guild.id) {
-                    client.sendMessage(Message(content: answer.cleaningMentions(with: guild)), to: channelId)
+                    sink.sendMessage(Message(content: answer.cleaningMentions(with: guild)), to: channelId)
                 } else {
-                    client.createReaction(for: messageId, on: channelId, emoji: "🤔")
+                    sink.createReaction(for: messageId, on: channelId, emoji: "🤔")
                 }
             }
             return true

--- a/Sources/D2Handlers/message/handler/MentionD2Handler.swift
+++ b/Sources/D2Handlers/message/handler/MentionD2Handler.swift
@@ -13,7 +13,7 @@ public struct MentionD2Handler: MessageHandler {
         self.conversator = conversator
     }
 
-    public func handleRaw(message: Message, from client: any MessageClient) -> Bool {
+    public func handleRaw(message: Message, from client: any MessageIOSink) -> Bool {
         if let me = client.me,
             !message.mentionEveryone,
             message.mentions(user: me),

--- a/Sources/D2Handlers/message/handler/MentionD2Handler.swift
+++ b/Sources/D2Handlers/message/handler/MentionD2Handler.swift
@@ -13,7 +13,7 @@ public struct MentionD2Handler: MessageHandler {
         self.conversator = conversator
     }
 
-    public func handleRaw(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handleRaw(message: Message, from client: any Sink) -> Bool {
         if let me = client.me,
             !message.mentionEveryone,
             message.mentions(user: me),

--- a/Sources/D2Handlers/message/handler/MentionSomeoneHandler.swift
+++ b/Sources/D2Handlers/message/handler/MentionSomeoneHandler.swift
@@ -3,7 +3,7 @@ import D2MessageIO
 public struct MentionSomeoneHandler: MessageHandler {
     private let rewriter = MentionSomeoneRewriter()
 
-    public func handleRaw(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handleRaw(message: Message, from client: any Sink) -> Bool {
         if let rewrite = rewriter.rewrite(message: message, from: client), let channelId = message.channelId {
             client.sendMessage(Message(content: rewrite.mentions.map { "<@\($0.id)>" }.joined(separator: " ")), to: channelId)
             return true

--- a/Sources/D2Handlers/message/handler/MentionSomeoneHandler.swift
+++ b/Sources/D2Handlers/message/handler/MentionSomeoneHandler.swift
@@ -3,7 +3,7 @@ import D2MessageIO
 public struct MentionSomeoneHandler: MessageHandler {
     private let rewriter = MentionSomeoneRewriter()
 
-    public func handleRaw(message: Message, from client: any MessageClient) -> Bool {
+    public func handleRaw(message: Message, from client: any MessageIOSink) -> Bool {
         if let rewrite = rewriter.rewrite(message: message, from: client), let channelId = message.channelId {
             client.sendMessage(Message(content: rewrite.mentions.map { "<@\($0.id)>" }.joined(separator: " ")), to: channelId)
             return true

--- a/Sources/D2Handlers/message/handler/MentionSomeoneHandler.swift
+++ b/Sources/D2Handlers/message/handler/MentionSomeoneHandler.swift
@@ -3,9 +3,9 @@ import D2MessageIO
 public struct MentionSomeoneHandler: MessageHandler {
     private let rewriter = MentionSomeoneRewriter()
 
-    public func handleRaw(message: Message, from client: any Sink) -> Bool {
-        if let rewrite = rewriter.rewrite(message: message, from: client), let channelId = message.channelId {
-            client.sendMessage(Message(content: rewrite.mentions.map { "<@\($0.id)>" }.joined(separator: " ")), to: channelId)
+    public func handleRaw(message: Message, sink: any Sink) -> Bool {
+        if let rewrite = rewriter.rewrite(message: message, sink: sink), let channelId = message.channelId {
+            sink.sendMessage(Message(content: rewrite.mentions.map { "<@\($0.id)>" }.joined(separator: " ")), to: channelId)
             return true
         } else {
             return false

--- a/Sources/D2Handlers/message/handler/MessageDatabaseHandler.swift
+++ b/Sources/D2Handlers/message/handler/MessageDatabaseHandler.swift
@@ -11,7 +11,7 @@ public struct MessageDatabaseHandler: MessageHandler {
         self.messageDB = messageDB
     }
 
-    public func handle(message: Message, from client: any MessageClient) -> Bool {
+    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
         if !(message.author?.bot ?? true) {
             if let guildId = message.guild?.id {
                 do {

--- a/Sources/D2Handlers/message/handler/MessageDatabaseHandler.swift
+++ b/Sources/D2Handlers/message/handler/MessageDatabaseHandler.swift
@@ -11,7 +11,7 @@ public struct MessageDatabaseHandler: MessageHandler {
         self.messageDB = messageDB
     }
 
-    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handle(message: Message, from client: any Sink) -> Bool {
         if !(message.author?.bot ?? true) {
             if let guildId = message.guild?.id {
                 do {

--- a/Sources/D2Handlers/message/handler/MessageDatabaseHandler.swift
+++ b/Sources/D2Handlers/message/handler/MessageDatabaseHandler.swift
@@ -11,7 +11,7 @@ public struct MessageDatabaseHandler: MessageHandler {
         self.messageDB = messageDB
     }
 
-    public func handle(message: Message, from client: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) -> Bool {
         if !(message.author?.bot ?? true) {
             if let guildId = message.guild?.id {
                 do {

--- a/Sources/D2Handlers/message/handler/MessageHandler.swift
+++ b/Sources/D2Handlers/message/handler/MessageHandler.swift
@@ -8,7 +8,7 @@ public protocol MessageHandler {
     /// Processes the message and returns whether it was handled (successfully).
     /// Handlers can also return false if they only "observed" the message, but
     /// did not intend to "consume" it.
-    mutating func handle(message: Message, from client: any Sink) -> Bool
+    mutating func handle(message: Message, sink: any Sink) -> Bool
 
     /// Processes the raw (non-rewritten) message and returns whether it was handled
     /// (sucessfully). This method will always be invoked prior to the actual handle
@@ -16,11 +16,11 @@ public protocol MessageHandler {
     ///
     /// Generally, you should avoid implementing this method unless you have a good
     /// reason to do so, since this may cause unintended message semantics.
-    mutating func handleRaw(message: Message, from client: any Sink) -> Bool
+    mutating func handleRaw(message: Message, sink: any Sink) -> Bool
 }
 
 public extension MessageHandler {
-    func handle(message: Message, from client: any Sink) -> Bool { false }
+    func handle(message: Message, sink: any Sink) -> Bool { false }
 
-    func handleRaw(message: Message, from client: any Sink) -> Bool { false }
+    func handleRaw(message: Message, sink: any Sink) -> Bool { false }
 }

--- a/Sources/D2Handlers/message/handler/MessageHandler.swift
+++ b/Sources/D2Handlers/message/handler/MessageHandler.swift
@@ -8,7 +8,7 @@ public protocol MessageHandler {
     /// Processes the message and returns whether it was handled (successfully).
     /// Handlers can also return false if they only "observed" the message, but
     /// did not intend to "consume" it.
-    mutating func handle(message: Message, from client: any MessageIOSink) -> Bool
+    mutating func handle(message: Message, from client: any Sink) -> Bool
 
     /// Processes the raw (non-rewritten) message and returns whether it was handled
     /// (sucessfully). This method will always be invoked prior to the actual handle
@@ -16,11 +16,11 @@ public protocol MessageHandler {
     ///
     /// Generally, you should avoid implementing this method unless you have a good
     /// reason to do so, since this may cause unintended message semantics.
-    mutating func handleRaw(message: Message, from client: any MessageIOSink) -> Bool
+    mutating func handleRaw(message: Message, from client: any Sink) -> Bool
 }
 
 public extension MessageHandler {
-    func handle(message: Message, from client: any MessageIOSink) -> Bool { false }
+    func handle(message: Message, from client: any Sink) -> Bool { false }
 
-    func handleRaw(message: Message, from client: any MessageIOSink) -> Bool { false }
+    func handleRaw(message: Message, from client: any Sink) -> Bool { false }
 }

--- a/Sources/D2Handlers/message/handler/MessageHandler.swift
+++ b/Sources/D2Handlers/message/handler/MessageHandler.swift
@@ -8,7 +8,7 @@ public protocol MessageHandler {
     /// Processes the message and returns whether it was handled (successfully).
     /// Handlers can also return false if they only "observed" the message, but
     /// did not intend to "consume" it.
-    mutating func handle(message: Message, from client: any MessageClient) -> Bool
+    mutating func handle(message: Message, from client: any MessageIOSink) -> Bool
 
     /// Processes the raw (non-rewritten) message and returns whether it was handled
     /// (sucessfully). This method will always be invoked prior to the actual handle
@@ -16,11 +16,11 @@ public protocol MessageHandler {
     ///
     /// Generally, you should avoid implementing this method unless you have a good
     /// reason to do so, since this may cause unintended message semantics.
-    mutating func handleRaw(message: Message, from client: any MessageClient) -> Bool
+    mutating func handleRaw(message: Message, from client: any MessageIOSink) -> Bool
 }
 
 public extension MessageHandler {
-    func handle(message: Message, from client: any MessageClient) -> Bool { false }
+    func handle(message: Message, from client: any MessageIOSink) -> Bool { false }
 
-    func handleRaw(message: Message, from client: any MessageClient) -> Bool { false }
+    func handleRaw(message: Message, from client: any MessageIOSink) -> Bool { false }
 }

--- a/Sources/D2Handlers/message/handler/MessagePreviewHandler.swift
+++ b/Sources/D2Handlers/message/handler/MessagePreviewHandler.swift
@@ -21,7 +21,7 @@ public struct MessagePreviewHandler: MessageHandler {
         self._configuration = configuration
     }
 
-    public func handle(message: Message, from client: any MessageClient) -> Bool {
+    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
         if client.name == "Discord",
             let guild = message.guild,
             configuration.enabledGuildIds.contains(guild.id),

--- a/Sources/D2Handlers/message/handler/MessagePreviewHandler.swift
+++ b/Sources/D2Handlers/message/handler/MessagePreviewHandler.swift
@@ -21,21 +21,21 @@ public struct MessagePreviewHandler: MessageHandler {
         self._configuration = configuration
     }
 
-    public func handle(message: Message, from client: any Sink) -> Bool {
-        if client.name == "Discord",
+    public func handle(message: Message, sink: any Sink) -> Bool {
+        if sink.name == "Discord",
             let guild = message.guild,
             configuration.enabledGuildIds.contains(guild.id),
             let parsedLink = messageLinkPattern.firstGroups(in: message.content),
             let channelId = message.channelId {
 
-            let previewedChannelId = ID(parsedLink[2], clientName: client.name)
-            let previewedMessageId = ID(parsedLink[3], clientName: client.name)
+            let previewedChannelId = ID(parsedLink[2], clientName: sink.name)
+            let previewedMessageId = ID(parsedLink[3], clientName: sink.name)
 
-            client.getMessages(for: previewedChannelId, limit: 1, selection: .around(previewedMessageId)).listenOrLogError { messages in
+            sink.getMessages(for: previewedChannelId, limit: 1, selection: .around(previewedMessageId)).listenOrLogError { messages in
                 if let message = messages.first,
                     let author = message.author,
                     let member = guild.members[author.id] {
-                    client.sendMessage(Message(embed: Embed(
+                    sink.sendMessage(Message(embed: Embed(
                         title: message.content.truncated(to: 200, appending: "..."),
                         author: Embed.Author(
                             name: member.displayName,

--- a/Sources/D2Handlers/message/handler/MessagePreviewHandler.swift
+++ b/Sources/D2Handlers/message/handler/MessagePreviewHandler.swift
@@ -21,7 +21,7 @@ public struct MessagePreviewHandler: MessageHandler {
         self._configuration = configuration
     }
 
-    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handle(message: Message, from client: any Sink) -> Bool {
         if client.name == "Discord",
             let guild = message.guild,
             configuration.enabledGuildIds.contains(guild.id),

--- a/Sources/D2Handlers/message/handler/SpamHandler.swift
+++ b/Sources/D2Handlers/message/handler/SpamHandler.swift
@@ -25,7 +25,7 @@ public struct SpamHandler: MessageHandler {
         lastSpamMessages = ExpiringList(dateProvider: dateProvider)
     }
 
-    public mutating func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public mutating func handle(message: Message, from client: any Sink) -> Bool {
         guard
             isPossiblySpam(message: message),
             let author = message.author,
@@ -58,7 +58,7 @@ public struct SpamHandler: MessageHandler {
         lastSpamMessages.count(forWhich: { ($0.author?.id).map { id in id == userId } ?? false }) > limits.maxSpamMessagesPerInterval
     }
 
-    private func penalize(spammer user: UserID, on guild: Guild, client: any MessageIOSink) {
+    private func penalize(spammer user: UserID, on guild: Guild, client: any Sink) {
         guard let member = guild.members[user] else { return }
 
         if let role = config.spammerRoles[guild.id] {
@@ -71,7 +71,7 @@ public struct SpamHandler: MessageHandler {
     }
 
     @discardableResult
-    private func add(role: RoleID, to user: UserID, on guild: Guild, client: any MessageIOSink) -> Promise<Void, any Error> {
+    private func add(role: RoleID, to user: UserID, on guild: Guild, client: any Sink) -> Promise<Void, any Error> {
         client.addGuildMemberRole(role, to: user, on: guild.id, reason: "Spamming").peekListen {
             if case .success(false) = $0 {
                 log.warning("Could not add role \(role) to spammer \(user)")
@@ -80,7 +80,7 @@ public struct SpamHandler: MessageHandler {
     }
 
     @discardableResult
-    private func remove(roles: [RoleID], from user: UserID, on guild: Guild, client: any MessageIOSink) -> Promise<Void, any Error> {
+    private func remove(roles: [RoleID], from user: UserID, on guild: Guild, client: any Sink) -> Promise<Void, any Error> {
         var remainingRoles = roles
         guard let role = remainingRoles.popLast() else {
             return Promise(.success(()))

--- a/Sources/D2Handlers/message/handler/SpamHandler.swift
+++ b/Sources/D2Handlers/message/handler/SpamHandler.swift
@@ -25,7 +25,7 @@ public struct SpamHandler: MessageHandler {
         lastSpamMessages = ExpiringList(dateProvider: dateProvider)
     }
 
-    public mutating func handle(message: Message, from client: any MessageClient) -> Bool {
+    public mutating func handle(message: Message, from client: any MessageIOSink) -> Bool {
         guard
             isPossiblySpam(message: message),
             let author = message.author,
@@ -58,7 +58,7 @@ public struct SpamHandler: MessageHandler {
         lastSpamMessages.count(forWhich: { ($0.author?.id).map { id in id == userId } ?? false }) > limits.maxSpamMessagesPerInterval
     }
 
-    private func penalize(spammer user: UserID, on guild: Guild, client: any MessageClient) {
+    private func penalize(spammer user: UserID, on guild: Guild, client: any MessageIOSink) {
         guard let member = guild.members[user] else { return }
 
         if let role = config.spammerRoles[guild.id] {
@@ -71,7 +71,7 @@ public struct SpamHandler: MessageHandler {
     }
 
     @discardableResult
-    private func add(role: RoleID, to user: UserID, on guild: Guild, client: any MessageClient) -> Promise<Void, any Error> {
+    private func add(role: RoleID, to user: UserID, on guild: Guild, client: any MessageIOSink) -> Promise<Void, any Error> {
         client.addGuildMemberRole(role, to: user, on: guild.id, reason: "Spamming").peekListen {
             if case .success(false) = $0 {
                 log.warning("Could not add role \(role) to spammer \(user)")
@@ -80,7 +80,7 @@ public struct SpamHandler: MessageHandler {
     }
 
     @discardableResult
-    private func remove(roles: [RoleID], from user: UserID, on guild: Guild, client: any MessageClient) -> Promise<Void, any Error> {
+    private func remove(roles: [RoleID], from user: UserID, on guild: Guild, client: any MessageIOSink) -> Promise<Void, any Error> {
         var remainingRoles = roles
         guard let role = remainingRoles.popLast() else {
             return Promise(.success(()))

--- a/Sources/D2Handlers/message/handler/SpamHandler.swift
+++ b/Sources/D2Handlers/message/handler/SpamHandler.swift
@@ -25,12 +25,12 @@ public struct SpamHandler: MessageHandler {
         lastSpamMessages = ExpiringList(dateProvider: dateProvider)
     }
 
-    public mutating func handle(message: Message, from client: any Sink) -> Bool {
+    public mutating func handle(message: Message, sink: any Sink) -> Bool {
         guard
             isPossiblySpam(message: message),
             let author = message.author,
             let channelId = message.channelId,
-            let guild = client.guildForChannel(channelId),
+            let guild = sink.guildForChannel(channelId),
             let daysOnGuild = guild.members[author.id].map({ Int(-$0.joinedAt.timeIntervalSinceNow / 86400) }),
             let limits = config.limitsByDaysOnGuild.filter({ daysOnGuild >= $0.key }).max(by: ascendingComparator(comparing: \.key))?.value else { return false }
 
@@ -38,10 +38,10 @@ public struct SpamHandler: MessageHandler {
 
         if isSpamming(userId: author.id, limits: limits) {
             if cautionedSpammers.contains(author.id) {
-                client.sendMessage(Message(content: ":octagonal_sign: Penalizing <@\(author.id)> for spamming!"), to: channelId)
-                penalize(spammer: author.id, on: guild, client: client)
+                sink.sendMessage(Message(content: ":octagonal_sign: Penalizing <@\(author.id)> for spamming!"), to: channelId)
+                penalize(spammer: author.id, on: guild, sink: sink)
             } else {
-                client.sendMessage(Message(content: ":warning: Please stop spamming, <@\(author.id)>!"), to: channelId)
+                sink.sendMessage(Message(content: ":warning: Please stop spamming, <@\(author.id)>!"), to: channelId)
                 cautionedSpammers.insert(author.id)
             }
             return true
@@ -58,21 +58,21 @@ public struct SpamHandler: MessageHandler {
         lastSpamMessages.count(forWhich: { ($0.author?.id).map { id in id == userId } ?? false }) > limits.maxSpamMessagesPerInterval
     }
 
-    private func penalize(spammer user: UserID, on guild: Guild, client: any Sink) {
+    private func penalize(spammer user: UserID, on guild: Guild, sink: any Sink) {
         guard let member = guild.members[user] else { return }
 
         if let role = config.spammerRoles[guild.id] {
-            add(role: role, to: user, on: guild, client: client).listenOrLogError {
+            add(role: role, to: user, on: guild, sink: sink).listenOrLogError {
                 if self.config.removeOtherRolesFromSpammer {
-                    self.remove(roles: member.roleIds, from: user, on: guild, client: client)
+                    self.remove(roles: member.roleIds, from: user, on: guild, sink: sink)
                 }
             }
         }
     }
 
     @discardableResult
-    private func add(role: RoleID, to user: UserID, on guild: Guild, client: any Sink) -> Promise<Void, any Error> {
-        client.addGuildMemberRole(role, to: user, on: guild.id, reason: "Spamming").peekListen {
+    private func add(role: RoleID, to user: UserID, on guild: Guild, sink: any Sink) -> Promise<Void, any Error> {
+        sink.addGuildMemberRole(role, to: user, on: guild.id, reason: "Spamming").peekListen {
             if case .success(false) = $0 {
                 log.warning("Could not add role \(role) to spammer \(user)")
             }
@@ -80,17 +80,17 @@ public struct SpamHandler: MessageHandler {
     }
 
     @discardableResult
-    private func remove(roles: [RoleID], from user: UserID, on guild: Guild, client: any Sink) -> Promise<Void, any Error> {
+    private func remove(roles: [RoleID], from user: UserID, on guild: Guild, sink: any Sink) -> Promise<Void, any Error> {
         var remainingRoles = roles
         guard let role = remainingRoles.popLast() else {
             return Promise(.success(()))
         }
 
-        return client.removeGuildMemberRole(role, from: user, on: guild.id, reason: "Spamming").then { success in
+        return sink.removeGuildMemberRole(role, from: user, on: guild.id, reason: "Spamming").then { success in
             if !success {
                 log.warning("Could not remove role \(role) from spammer \(user)")
             }
-            return self.remove(roles: remainingRoles, from: user, on: guild, client: client)
+            return self.remove(roles: remainingRoles, from: user, on: guild, sink: sink)
         }
     }
 }

--- a/Sources/D2Handlers/message/handler/SubscriptionHandler.swift
+++ b/Sources/D2Handlers/message/handler/SubscriptionHandler.swift
@@ -21,7 +21,7 @@ public struct SubscriptionHandler: MessageHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(message: Message, from client: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) -> Bool {
         guard !manager.isEmpty, let channelId = message.channelId else { return false }
 
         let isBot = message.author?.bot ?? false
@@ -29,7 +29,7 @@ public struct SubscriptionHandler: MessageHandler {
 
         manager.notifySubscriptions(on: channelId, isBot: isBot) { name, subs in
             let context = CommandContext(
-                client: client,
+                sink: sink,
                 registry: registry,
                 message: message,
                 commandPrefix: commandPrefix,
@@ -41,7 +41,7 @@ public struct SubscriptionHandler: MessageHandler {
             let output = MessageIOOutput(context: context) { sentMessages in
                 for sent in sentMessages {
                     command?.onSuccessfullySent(context: CommandContext(
-                        client: client,
+                        sink: sink,
                         registry: registry,
                         message: sent,
                         commandPrefix: commandPrefix,

--- a/Sources/D2Handlers/message/handler/SubscriptionHandler.swift
+++ b/Sources/D2Handlers/message/handler/SubscriptionHandler.swift
@@ -21,7 +21,7 @@ public struct SubscriptionHandler: MessageHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handle(message: Message, from client: any Sink) -> Bool {
         guard !manager.isEmpty, let channelId = message.channelId else { return false }
 
         let isBot = message.author?.bot ?? false

--- a/Sources/D2Handlers/message/handler/SubscriptionHandler.swift
+++ b/Sources/D2Handlers/message/handler/SubscriptionHandler.swift
@@ -21,7 +21,7 @@ public struct SubscriptionHandler: MessageHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(message: Message, from client: any MessageClient) -> Bool {
+    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
         guard !manager.isEmpty, let channelId = message.channelId else { return false }
 
         let isBot = message.author?.bot ?? false

--- a/Sources/D2Handlers/message/handler/TriggerReactionHandler.swift
+++ b/Sources/D2Handlers/message/handler/TriggerReactionHandler.swift
@@ -67,12 +67,12 @@ public struct TriggerReactionHandler: MessageHandler {
         ])
     }
 
-    public func handle(message: Message, from client: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) -> Bool {
         if let messageId = message.id, let channelId = message.channelId {
             for trigger in triggers {
                 trigger.emoji(message).listen {
                     if case let .success(emoji) = $0 {
-                        client.createReaction(for: messageId, on: channelId, emoji: emoji)
+                        sink.createReaction(for: messageId, on: channelId, emoji: emoji)
                     }
                 }
             }

--- a/Sources/D2Handlers/message/handler/TriggerReactionHandler.swift
+++ b/Sources/D2Handlers/message/handler/TriggerReactionHandler.swift
@@ -67,7 +67,7 @@ public struct TriggerReactionHandler: MessageHandler {
         ])
     }
 
-    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handle(message: Message, from client: any Sink) -> Bool {
         if let messageId = message.id, let channelId = message.channelId {
             for trigger in triggers {
                 trigger.emoji(message).listen {

--- a/Sources/D2Handlers/message/handler/TriggerReactionHandler.swift
+++ b/Sources/D2Handlers/message/handler/TriggerReactionHandler.swift
@@ -67,7 +67,7 @@ public struct TriggerReactionHandler: MessageHandler {
         ])
     }
 
-    public func handle(message: Message, from client: any MessageClient) -> Bool {
+    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
         if let messageId = message.id, let channelId = message.channelId {
             for trigger in triggers {
                 trigger.emoji(message).listen {

--- a/Sources/D2Handlers/message/handler/UniversalSummoningHandler.swift
+++ b/Sources/D2Handlers/message/handler/UniversalSummoningHandler.swift
@@ -11,7 +11,7 @@ public struct UniversalSummoningHandler: MessageHandler {
         self.hostInfo = hostInfo
     }
 
-    public func handle(message: Message, from client: any MessageClient) -> Bool {
+    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
         if message.content.trimmingCharacters(in: .whitespacesAndNewlines) == theMagicWords,
            let channelId = message.channelId {
             client.sendMessage(Message(content: "Hey, \(hostInfo.instanceName ?? "unknown D2") here"), to: channelId)

--- a/Sources/D2Handlers/message/handler/UniversalSummoningHandler.swift
+++ b/Sources/D2Handlers/message/handler/UniversalSummoningHandler.swift
@@ -11,7 +11,7 @@ public struct UniversalSummoningHandler: MessageHandler {
         self.hostInfo = hostInfo
     }
 
-    public func handle(message: Message, from client: any MessageIOSink) -> Bool {
+    public func handle(message: Message, from client: any Sink) -> Bool {
         if message.content.trimmingCharacters(in: .whitespacesAndNewlines) == theMagicWords,
            let channelId = message.channelId {
             client.sendMessage(Message(content: "Hey, \(hostInfo.instanceName ?? "unknown D2") here"), to: channelId)

--- a/Sources/D2Handlers/message/handler/UniversalSummoningHandler.swift
+++ b/Sources/D2Handlers/message/handler/UniversalSummoningHandler.swift
@@ -11,10 +11,10 @@ public struct UniversalSummoningHandler: MessageHandler {
         self.hostInfo = hostInfo
     }
 
-    public func handle(message: Message, from client: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) -> Bool {
         if message.content.trimmingCharacters(in: .whitespacesAndNewlines) == theMagicWords,
            let channelId = message.channelId {
-            client.sendMessage(Message(content: "Hey, \(hostInfo.instanceName ?? "unknown D2") here"), to: channelId)
+            sink.sendMessage(Message(content: "Hey, \(hostInfo.instanceName ?? "unknown D2") here"), to: channelId)
             return true
         }
         return false

--- a/Sources/D2Handlers/message/rewriter/MentionSomeoneRewriter.swift
+++ b/Sources/D2Handlers/message/rewriter/MentionSomeoneRewriter.swift
@@ -4,7 +4,7 @@ import Utils
 fileprivate let someonePattern = try! Regex(from: "@someone")
 
 public struct MentionSomeoneRewriter: MessageRewriter {
-    public func rewrite(message: Message, from client: any MessageClient) -> Message? {
+    public func rewrite(message: Message, from client: any MessageIOSink) -> Message? {
         var m = message
         let mentionCount = someonePattern.matchCount(in: m.content)
         if mentionCount > 0,

--- a/Sources/D2Handlers/message/rewriter/MentionSomeoneRewriter.swift
+++ b/Sources/D2Handlers/message/rewriter/MentionSomeoneRewriter.swift
@@ -4,7 +4,7 @@ import Utils
 fileprivate let someonePattern = try! Regex(from: "@someone")
 
 public struct MentionSomeoneRewriter: MessageRewriter {
-    public func rewrite(message: Message, from client: any MessageIOSink) -> Message? {
+    public func rewrite(message: Message, from client: any Sink) -> Message? {
         var m = message
         let mentionCount = someonePattern.matchCount(in: m.content)
         if mentionCount > 0,

--- a/Sources/D2Handlers/message/rewriter/MentionSomeoneRewriter.swift
+++ b/Sources/D2Handlers/message/rewriter/MentionSomeoneRewriter.swift
@@ -4,7 +4,7 @@ import Utils
 fileprivate let someonePattern = try! Regex(from: "@someone")
 
 public struct MentionSomeoneRewriter: MessageRewriter {
-    public func rewrite(message: Message, from client: any Sink) -> Message? {
+    public func rewrite(message: Message, sink: any Sink) -> Message? {
         var m = message
         let mentionCount = someonePattern.matchCount(in: m.content)
         if mentionCount > 0,

--- a/Sources/D2Handlers/message/rewriter/MessageRewriter.swift
+++ b/Sources/D2Handlers/message/rewriter/MessageRewriter.swift
@@ -2,5 +2,5 @@ import D2MessageIO
 
 /// Represents anything that modifies an (incoming) message.
 public protocol MessageRewriter {
-    func rewrite(message: Message, from client: any MessageClient) -> Message?
+    func rewrite(message: Message, from client: any MessageIOSink) -> Message?
 }

--- a/Sources/D2Handlers/message/rewriter/MessageRewriter.swift
+++ b/Sources/D2Handlers/message/rewriter/MessageRewriter.swift
@@ -2,5 +2,5 @@ import D2MessageIO
 
 /// Represents anything that modifies an (incoming) message.
 public protocol MessageRewriter {
-    func rewrite(message: Message, from client: any MessageIOSink) -> Message?
+    func rewrite(message: Message, from client: any Sink) -> Message?
 }

--- a/Sources/D2Handlers/message/rewriter/MessageRewriter.swift
+++ b/Sources/D2Handlers/message/rewriter/MessageRewriter.swift
@@ -2,5 +2,5 @@ import D2MessageIO
 
 /// Represents anything that modifies an (incoming) message.
 public protocol MessageRewriter {
-    func rewrite(message: Message, from client: any Sink) -> Message?
+    func rewrite(message: Message, sink: any Sink) -> Message?
 }

--- a/Sources/D2Handlers/presence/handler/PresenceHandler.swift
+++ b/Sources/D2Handlers/presence/handler/PresenceHandler.swift
@@ -5,5 +5,5 @@ import D2MessageIO
 public protocol PresenceHandler {
     /// Handles a single presence update. Is invoked
     /// for each presence after connecting.
-    mutating func handle(presenceUpdate presence: Presence, client: any Sink)
+    mutating func handle(presenceUpdate presence: Presence, sink: any Sink)
 }

--- a/Sources/D2Handlers/presence/handler/PresenceHandler.swift
+++ b/Sources/D2Handlers/presence/handler/PresenceHandler.swift
@@ -5,5 +5,5 @@ import D2MessageIO
 public protocol PresenceHandler {
     /// Handles a single presence update. Is invoked
     /// for each presence after connecting.
-    mutating func handle(presenceUpdate presence: Presence, client: any MessageClient)
+    mutating func handle(presenceUpdate presence: Presence, client: any MessageIOSink)
 }

--- a/Sources/D2Handlers/presence/handler/PresenceHandler.swift
+++ b/Sources/D2Handlers/presence/handler/PresenceHandler.swift
@@ -5,5 +5,5 @@ import D2MessageIO
 public protocol PresenceHandler {
     /// Handles a single presence update. Is invoked
     /// for each presence after connecting.
-    mutating func handle(presenceUpdate presence: Presence, client: any MessageIOSink)
+    mutating func handle(presenceUpdate presence: Presence, client: any Sink)
 }

--- a/Sources/D2Handlers/presence/handler/StreamerRoleHandler.swift
+++ b/Sources/D2Handlers/presence/handler/StreamerRoleHandler.swift
@@ -16,7 +16,7 @@ public struct StreamerRoleHandler: PresenceHandler {
         self._streamerRoleConfiguration = streamerRoleConfiguration
     }
 
-    public func handle(presenceUpdate presence: Presence, client: any MessageClient) {
+    public func handle(presenceUpdate presence: Presence, client: any MessageIOSink) {
         log.trace("Presence activities: \(presence.activities)")
         guard let guildId = presence.guildId else { return }
         if

--- a/Sources/D2Handlers/presence/handler/StreamerRoleHandler.swift
+++ b/Sources/D2Handlers/presence/handler/StreamerRoleHandler.swift
@@ -16,7 +16,7 @@ public struct StreamerRoleHandler: PresenceHandler {
         self._streamerRoleConfiguration = streamerRoleConfiguration
     }
 
-    public func handle(presenceUpdate presence: Presence, client: any MessageIOSink) {
+    public func handle(presenceUpdate presence: Presence, client: any Sink) {
         log.trace("Presence activities: \(presence.activities)")
         guard let guildId = presence.guildId else { return }
         if

--- a/Sources/D2Handlers/presence/handler/StreamerRoleHandler.swift
+++ b/Sources/D2Handlers/presence/handler/StreamerRoleHandler.swift
@@ -16,17 +16,17 @@ public struct StreamerRoleHandler: PresenceHandler {
         self._streamerRoleConfiguration = streamerRoleConfiguration
     }
 
-    public func handle(presenceUpdate presence: Presence, client: any Sink) {
+    public func handle(presenceUpdate presence: Presence, sink: any Sink) {
         log.trace("Presence activities: \(presence.activities)")
         guard let guildId = presence.guildId else { return }
         if
             let roleId = streamerRoleConfiguration.streamerRoles[guildId],
-            let guild = client.guild(for: guildId),
+            let guild = sink.guild(for: guildId),
             let member = guild.members[presence.user.id] {
             if presence.activities.contains(where: { $0.type == .stream }) {
                 if !member.roleIds.contains(roleId) {
                     log.info("Adding streamer role to \(member.displayName)")
-                    client.addGuildMemberRole(roleId, to: presence.user.id, on: guildId, reason: "Streaming").listenOrLogError { success in
+                    sink.addGuildMemberRole(roleId, to: presence.user.id, on: guildId, reason: "Streaming").listenOrLogError { success in
                         if !success {
                             log.warning("Adding streamer role to \(member.displayName) failed")
                         }
@@ -36,7 +36,7 @@ public struct StreamerRoleHandler: PresenceHandler {
                 }
             } else if member.roleIds.contains(roleId) {
                 log.info("Removing streamer role from \(member.displayName)")
-                client.removeGuildMemberRole(roleId, from: presence.user.id, on: guildId, reason: "No longer streaming")
+                sink.removeGuildMemberRole(roleId, from: presence.user.id, on: guildId, reason: "No longer streaming")
             } else {
                 log.debug("Not removing streamer role from \(member.displayName).")
             }

--- a/Sources/D2Handlers/reaction/handler/MessageDatabaseReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/MessageDatabaseReactionHandler.swift
@@ -11,7 +11,7 @@ public struct MessageDatabaseReactionHandler: ReactionHandler {
         self.messageDB = messageDB
     }
 
-    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
+    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
         do {
             if try messageDB.isTracked(channelId: channelId) {
                 try messageDB.add(reaction: emoji, to: messageId, by: userId)
@@ -22,7 +22,7 @@ public struct MessageDatabaseReactionHandler: ReactionHandler {
         }
     }
 
-    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
+    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
         do {
             if try messageDB.isTracked(channelId: channelId) {
                 try messageDB.remove(reaction: emoji, from: messageId, by: userId)
@@ -33,7 +33,7 @@ public struct MessageDatabaseReactionHandler: ReactionHandler {
         }
     }
 
-    public func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageIOSink) {
+    public func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any Sink) {
         do {
             if try messageDB.isTracked(channelId: channelId) {
                 try messageDB.remove(allReactionsFrom: messageId)

--- a/Sources/D2Handlers/reaction/handler/MessageDatabaseReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/MessageDatabaseReactionHandler.swift
@@ -11,7 +11,7 @@ public struct MessageDatabaseReactionHandler: ReactionHandler {
         self.messageDB = messageDB
     }
 
-    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
+    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {
         do {
             if try messageDB.isTracked(channelId: channelId) {
                 try messageDB.add(reaction: emoji, to: messageId, by: userId)
@@ -22,7 +22,7 @@ public struct MessageDatabaseReactionHandler: ReactionHandler {
         }
     }
 
-    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
+    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {
         do {
             if try messageDB.isTracked(channelId: channelId) {
                 try messageDB.remove(reaction: emoji, from: messageId, by: userId)
@@ -33,7 +33,7 @@ public struct MessageDatabaseReactionHandler: ReactionHandler {
         }
     }
 
-    public func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any Sink) {
+    public func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, sink: any Sink) {
         do {
             if try messageDB.isTracked(channelId: channelId) {
                 try messageDB.remove(allReactionsFrom: messageId)

--- a/Sources/D2Handlers/reaction/handler/MessageDatabaseReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/MessageDatabaseReactionHandler.swift
@@ -11,7 +11,7 @@ public struct MessageDatabaseReactionHandler: ReactionHandler {
         self.messageDB = messageDB
     }
 
-    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {
+    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
         do {
             if try messageDB.isTracked(channelId: channelId) {
                 try messageDB.add(reaction: emoji, to: messageId, by: userId)
@@ -22,7 +22,7 @@ public struct MessageDatabaseReactionHandler: ReactionHandler {
         }
     }
 
-    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {
+    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
         do {
             if try messageDB.isTracked(channelId: channelId) {
                 try messageDB.remove(reaction: emoji, from: messageId, by: userId)
@@ -33,7 +33,7 @@ public struct MessageDatabaseReactionHandler: ReactionHandler {
         }
     }
 
-    public func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageClient) {
+    public func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageIOSink) {
         do {
             if try messageDB.isTracked(channelId: channelId) {
                 try messageDB.remove(allReactionsFrom: messageId)

--- a/Sources/D2Handlers/reaction/handler/ReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/ReactionHandler.swift
@@ -3,17 +3,17 @@ import D2MessageIO
 /// Anything that handles incoming reactions
 /// to messages from Discord.
 public protocol ReactionHandler {
-    mutating func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink)
+    mutating func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink)
 
-    mutating func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink)
+    mutating func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink)
 
-    mutating func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageIOSink)
+    mutating func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any Sink)
 }
 
 public extension ReactionHandler {
-    func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {}
+    func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {}
 
-    func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {}
+    func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {}
 
-    func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageIOSink) {}
+    func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any Sink) {}
 }

--- a/Sources/D2Handlers/reaction/handler/ReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/ReactionHandler.swift
@@ -3,17 +3,17 @@ import D2MessageIO
 /// Anything that handles incoming reactions
 /// to messages from Discord.
 public protocol ReactionHandler {
-    mutating func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink)
+    mutating func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink)
 
-    mutating func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink)
+    mutating func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink)
 
-    mutating func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any Sink)
+    mutating func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, sink: any Sink)
 }
 
 public extension ReactionHandler {
-    func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {}
+    func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {}
 
-    func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {}
+    func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {}
 
-    func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any Sink) {}
+    func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, sink: any Sink) {}
 }

--- a/Sources/D2Handlers/reaction/handler/ReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/ReactionHandler.swift
@@ -3,17 +3,17 @@ import D2MessageIO
 /// Anything that handles incoming reactions
 /// to messages from Discord.
 public protocol ReactionHandler {
-    mutating func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient)
+    mutating func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink)
 
-    mutating func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient)
+    mutating func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink)
 
-    mutating func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageClient)
+    mutating func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageIOSink)
 }
 
 public extension ReactionHandler {
-    func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {}
+    func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {}
 
-    func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {}
+    func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {}
 
-    func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageClient) {}
+    func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, client: any MessageIOSink) {}
 }

--- a/Sources/D2Handlers/reaction/handler/RoleReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/RoleReactionHandler.swift
@@ -12,7 +12,7 @@ public struct RoleReactionHandler: ReactionHandler {
         self._configuration = configuration
     }
 
-    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
+    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
         if
             let roleId = configuration.roleMessages[messageId]?[emoji.compactDescription],
             let guild = client.guildForChannel(channelId),
@@ -25,7 +25,7 @@ public struct RoleReactionHandler: ReactionHandler {
         }
     }
 
-    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
+    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
         if
             let roleId = configuration.roleMessages[messageId]?[emoji.compactDescription],
             let guild = client.guildForChannel(channelId),

--- a/Sources/D2Handlers/reaction/handler/RoleReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/RoleReactionHandler.swift
@@ -12,7 +12,7 @@ public struct RoleReactionHandler: ReactionHandler {
         self._configuration = configuration
     }
 
-    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {
+    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
         if
             let roleId = configuration.roleMessages[messageId]?[emoji.compactDescription],
             let guild = client.guildForChannel(channelId),
@@ -25,7 +25,7 @@ public struct RoleReactionHandler: ReactionHandler {
         }
     }
 
-    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {
+    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
         if
             let roleId = configuration.roleMessages[messageId]?[emoji.compactDescription],
             let guild = client.guildForChannel(channelId),

--- a/Sources/D2Handlers/reaction/handler/RoleReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/RoleReactionHandler.swift
@@ -12,29 +12,29 @@ public struct RoleReactionHandler: ReactionHandler {
         self._configuration = configuration
     }
 
-    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
+    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {
         if
             let roleId = configuration.roleMessages[messageId]?[emoji.compactDescription],
-            let guild = client.guildForChannel(channelId),
+            let guild = sink.guildForChannel(channelId),
             let role = guild.roles[roleId],
             let member = guild.members[userId],
             !member.user.bot,
             !member.roleIds.contains(roleId) {
             log.info("Adding role \(role.name) upong reaction to \(member.displayName)")
-            client.addGuildMemberRole(roleId, to: userId, on: guild.id, reason: "Reaction")
+            sink.addGuildMemberRole(roleId, to: userId, on: guild.id, reason: "Reaction")
         }
     }
 
-    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
+    public func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {
         if
             let roleId = configuration.roleMessages[messageId]?[emoji.compactDescription],
-            let guild = client.guildForChannel(channelId),
+            let guild = sink.guildForChannel(channelId),
             let role = guild.roles[roleId],
             let member = guild.members[userId],
             !member.user.bot,
             member.roleIds.contains(roleId) {
             log.info("Removing role \(role.name) upong reaction from \(member.displayName)")
-            client.removeGuildMemberRole(roleId, from: userId, on: guild.id, reason: "Reaction")
+            sink.removeGuildMemberRole(roleId, from: userId, on: guild.id, reason: "Reaction")
         }
     }
 }

--- a/Sources/D2Handlers/reaction/handler/SubscriptionReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/SubscriptionReactionHandler.swift
@@ -15,7 +15,7 @@ public struct SubscriptionReactionHandler: ReactionHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {
+    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
         guard
             let guild = client.guildForChannel(channelId),
             let member = guild.members[userId] else { return }

--- a/Sources/D2Handlers/reaction/handler/SubscriptionReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/SubscriptionReactionHandler.swift
@@ -15,16 +15,16 @@ public struct SubscriptionReactionHandler: ReactionHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
+    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {
         guard
-            let guild = client.guildForChannel(channelId),
+            let guild = sink.guildForChannel(channelId),
             let member = guild.members[userId] else { return }
         // TODO: Query the actual message that the user reacted to here
         let message = Message(content: "Dummy", channelId: channelId, id: messageId)
         let user = member.user
         manager.notifySubscriptions(on: channelId, isBot: user.bot) {
             let context = CommandContext(
-                client: client,
+                sink: sink,
                 registry: registry,
                 message: message,
                 commandPrefix: commandPrefix,

--- a/Sources/D2Handlers/reaction/handler/SubscriptionReactionHandler.swift
+++ b/Sources/D2Handlers/reaction/handler/SubscriptionReactionHandler.swift
@@ -15,7 +15,7 @@ public struct SubscriptionReactionHandler: ReactionHandler {
         self.eventLoopGroup = eventLoopGroup
     }
 
-    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {
+    public func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {
         guard
             let guild = client.guildForChannel(channelId),
             let member = guild.members[userId] else { return }

--- a/Sources/D2IRCIO/IRCClientManager.swift
+++ b/Sources/D2IRCIO/IRCClientManager.swift
@@ -5,7 +5,7 @@ import D2MessageIO
 fileprivate let log = Logger(label: "D2IRCIO.IRCClientManager")
 
 public class IRCClientManager: IRCClientDelegate {
-    private let inner: any MessageDelegate
+    private let receiver: any Receiver
     private let combinedSink: CombinedSink
     private let name: String
 
@@ -15,14 +15,14 @@ public class IRCClientManager: IRCClientDelegate {
     private var ircClient: IRCClient
 
     public init(
-        inner: any MessageDelegate,
+        receiver: any Receiver,
         combinedSink: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         config: IRCConfig,
         name: String,
         channelsToJoin: [String]
     ) {
-        self.inner = inner
+        self.receiver = receiver
         self.combinedSink = combinedSink
         self.name = name
         self.channelsToJoin = channelsToJoin
@@ -85,7 +85,7 @@ public class IRCClientManager: IRCClientDelegate {
             channelId: ID(channelName.stringValue, clientName: name)
         )
 
-        inner.on(createMessage: m, sink: overlaySink(with: ircClient))
+        receiver.on(createMessage: m, sink: overlaySink(with: ircClient))
     }
 
     private func overlaySink(with ircClient: IRCClient) -> Sink {

--- a/Sources/D2IRCIO/IRCClientManager.swift
+++ b/Sources/D2IRCIO/IRCClientManager.swift
@@ -1,4 +1,5 @@
 import IRC
+import NIO
 import Logging
 import D2MessageIO
 

--- a/Sources/D2IRCIO/IRCClientManager.swift
+++ b/Sources/D2IRCIO/IRCClientManager.swift
@@ -6,7 +6,7 @@ fileprivate let log = Logger(label: "D2IRCIO.IRCClientManager")
 
 public class IRCClientManager: IRCClientDelegate {
     private let inner: any MessageDelegate
-    private let combinedClient: any MessageIOSink
+    private let combinedClient: any Sink
     private let name: String
 
     private var joined: Bool = false
@@ -16,7 +16,7 @@ public class IRCClientManager: IRCClientDelegate {
 
     public init(
         inner: any MessageDelegate,
-        combinedClient: CombinedMessageIOSink,
+        combinedClient: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         config: IRCConfig,
         name: String,
@@ -88,7 +88,7 @@ public class IRCClientManager: IRCClientDelegate {
         inner.on(createMessage: m, client: overlayClient(with: ircClient))
     }
 
-    private func overlayClient(with ircClient: IRCClient) -> MessageIOSink {
-        OverlayMessageIOSink(inner: combinedClient, name: name)
+    private func overlayClient(with ircClient: IRCClient) -> Sink {
+        OverlaySink(inner: combinedClient, name: name)
     }
 }

--- a/Sources/D2IRCIO/IRCClientManager.swift
+++ b/Sources/D2IRCIO/IRCClientManager.swift
@@ -6,7 +6,7 @@ fileprivate let log = Logger(label: "D2IRCIO.IRCClientManager")
 
 public class IRCClientManager: IRCClientDelegate {
     private let inner: any MessageDelegate
-    private let combinedClient: any Sink
+    private let combinedSink: CombinedSink
     private let name: String
 
     private var joined: Bool = false
@@ -16,14 +16,14 @@ public class IRCClientManager: IRCClientDelegate {
 
     public init(
         inner: any MessageDelegate,
-        combinedClient: CombinedSink,
+        combinedSink: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         config: IRCConfig,
         name: String,
         channelsToJoin: [String]
     ) {
         self.inner = inner
-        self.combinedClient = combinedClient
+        self.combinedSink = combinedSink
         self.name = name
         self.channelsToJoin = channelsToJoin
 
@@ -36,7 +36,7 @@ public class IRCClientManager: IRCClientDelegate {
         ))
         ircClient.delegate = self
 
-        combinedClient.register(client: IRCSink(ircClient: ircClient, name: name))
+        combinedSink.register(sink: IRCSink(client: ircClient, name: name))
     }
 
     public func connect() {
@@ -85,10 +85,10 @@ public class IRCClientManager: IRCClientDelegate {
             channelId: ID(channelName.stringValue, clientName: name)
         )
 
-        inner.on(createMessage: m, client: overlayClient(with: ircClient))
+        inner.on(createMessage: m, sink: overlaySink(with: ircClient))
     }
 
-    private func overlayClient(with ircClient: IRCClient) -> Sink {
-        OverlaySink(inner: combinedClient, name: name)
+    private func overlaySink(with ircClient: IRCClient) -> Sink {
+        OverlaySink(inner: combinedSink, name: name)
     }
 }

--- a/Sources/D2IRCIO/IRCClientManager.swift
+++ b/Sources/D2IRCIO/IRCClientManager.swift
@@ -6,7 +6,7 @@ fileprivate let log = Logger(label: "D2IRCIO.IRCClientManager")
 
 public class IRCClientManager: IRCClientDelegate {
     private let inner: any MessageDelegate
-    private let combinedClient: any MessageClient
+    private let combinedClient: any MessageIOSink
     private let name: String
 
     private var joined: Bool = false
@@ -16,7 +16,7 @@ public class IRCClientManager: IRCClientDelegate {
 
     public init(
         inner: any MessageDelegate,
-        combinedClient: CombinedMessageClient,
+        combinedClient: CombinedMessageIOSink,
         eventLoopGroup: any EventLoopGroup,
         config: IRCConfig,
         name: String,
@@ -36,7 +36,7 @@ public class IRCClientManager: IRCClientDelegate {
         ))
         ircClient.delegate = self
 
-        combinedClient.register(client: IRCMessageClient(ircClient: ircClient, name: name))
+        combinedClient.register(client: IRCSink(ircClient: ircClient, name: name))
     }
 
     public func connect() {
@@ -88,7 +88,7 @@ public class IRCClientManager: IRCClientDelegate {
         inner.on(createMessage: m, client: overlayClient(with: ircClient))
     }
 
-    private func overlayClient(with ircClient: IRCClient) -> MessageClient {
-        OverlayMessageClient(inner: combinedClient, name: name)
+    private func overlayClient(with ircClient: IRCClient) -> MessageIOSink {
+        OverlayMessageIOSink(inner: combinedClient, name: name)
     }
 }

--- a/Sources/D2IRCIO/IRCMessageClientError.swift
+++ b/Sources/D2IRCIO/IRCMessageClientError.swift
@@ -1,3 +1,0 @@
-public enum IRCMessageClientError: Error {
-    case invalidChannelName(String)
-}

--- a/Sources/D2IRCIO/IRCPlatform.swift
+++ b/Sources/D2IRCIO/IRCPlatform.swift
@@ -13,7 +13,7 @@ public struct IRCPlatform: MessagePlatform {
 
     public init(
         with delegate: any MessageDelegate,
-        combinedClient: CombinedMessageClient,
+        combinedClient: CombinedMessageIOSink,
         eventLoopGroup: any EventLoopGroup,
         token config: IRCConfig
     ) throws {

--- a/Sources/D2IRCIO/IRCPlatform.swift
+++ b/Sources/D2IRCIO/IRCPlatform.swift
@@ -12,7 +12,7 @@ public struct IRCPlatform: MessagePlatform {
     public let name: String
 
     public init(
-        with delegate: any MessageDelegate,
+        receiver: any Receiver,
         combinedSink: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token config: IRCConfig
@@ -22,7 +22,7 @@ public struct IRCPlatform: MessagePlatform {
 
         log.info("Initializing IRC backend (\(config.host):\(config.port))...")
         manager = IRCClientManager(
-            inner: delegate,
+            receiver: receiver,
             combinedSink: combinedSink,
             eventLoopGroup: eventLoopGroup,
             config: config,

--- a/Sources/D2IRCIO/IRCPlatform.swift
+++ b/Sources/D2IRCIO/IRCPlatform.swift
@@ -13,7 +13,7 @@ public struct IRCPlatform: MessagePlatform {
 
     public init(
         with delegate: any MessageDelegate,
-        combinedClient: CombinedSink,
+        combinedSink: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token config: IRCConfig
     ) throws {
@@ -23,7 +23,7 @@ public struct IRCPlatform: MessagePlatform {
         log.info("Initializing IRC backend (\(config.host):\(config.port))...")
         manager = IRCClientManager(
             inner: delegate,
-            combinedClient: combinedClient,
+            combinedSink: combinedSink,
             eventLoopGroup: eventLoopGroup,
             config: config,
             name: name,

--- a/Sources/D2IRCIO/IRCPlatform.swift
+++ b/Sources/D2IRCIO/IRCPlatform.swift
@@ -13,7 +13,7 @@ public struct IRCPlatform: MessagePlatform {
 
     public init(
         with delegate: any MessageDelegate,
-        combinedClient: CombinedMessageIOSink,
+        combinedClient: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token config: IRCConfig
     ) throws {

--- a/Sources/D2IRCIO/IRCPlatform.swift
+++ b/Sources/D2IRCIO/IRCPlatform.swift
@@ -7,7 +7,8 @@ fileprivate let log = Logger(label: "D2IRCIO.IRCPlatform")
 
 public struct IRCPlatform: MessagePlatform {
     private let config: IRCConfig
-    private let ircClient: IRCClient
+    private let manager: IRCClientManager
+
     public let name: String
 
     public init(
@@ -20,21 +21,18 @@ public struct IRCPlatform: MessagePlatform {
         name = "IRC \(config.host):\(config.port)"
 
         log.info("Initializing IRC backend (\(config.host):\(config.port))...")
-        ircClient = IRCClient(options: IRCClientOptions(
-            port: config.port,
-            host: config.host,
-            password: config.password,
-            nickname: IRCNickName(config.nickname)!,
-            eventLoopGroup: eventLoopGroup
-        ))
-
-        combinedClient.register(client: IRCMessageClient(ircClient: ircClient, name: name))
-
-        ircClient.delegate = MessageIOClientDelegate(inner: delegate, sinkClient: combinedClient, name: name, channelsToJoin: config.autojoinedChannels ?? [])
+        manager = IRCClientManager(
+            inner: delegate,
+            combinedClient: combinedClient,
+            eventLoopGroup: eventLoopGroup,
+            config: config,
+            name: name,
+            channelsToJoin: config.autojoinedChannels ?? []
+        )
     }
 
     public func start() throws {
         log.info("Starting IRC client (\(config.host):\(config.port))")
-        ircClient.connect()
+        manager.connect()
     }
 }

--- a/Sources/D2IRCIO/IRCSink.swift
+++ b/Sources/D2IRCIO/IRCSink.swift
@@ -5,10 +5,10 @@ import Emoji
 import IRC
 import Logging
 
-fileprivate let log = Logger(label: "D2IRCIO.IRCMessageClient")
+fileprivate let log = Logger(label: "D2IRCIO.IRCSink")
 fileprivate let mentionPattern = try! Regex(from: "<@.+?>")
 
-struct IRCMessageClient: DefaultMessageClient {
+struct IRCSink: DefaultMessageIOSink {
     private let ircClient: IRCClient
 
     let name: String
@@ -43,7 +43,7 @@ struct IRCMessageClient: DefaultMessageClient {
 
         guard let channelName = IRCChannelName(channelId.value) else {
             log.warning("Could not convert \(channelId.value) (maybe it is missing a leading '#'?)")
-            return Promise(.failure(IRCMessageClientError.invalidChannelName(channelId.value)))
+            return Promise(.failure(IRCSinkError.invalidChannelName(channelId.value)))
         }
 
         ircClient.send(.PRIVMSG([.channel(channelName)], text))

--- a/Sources/D2IRCIO/IRCSink.swift
+++ b/Sources/D2IRCIO/IRCSink.swift
@@ -9,12 +9,12 @@ fileprivate let log = Logger(label: "D2IRCIO.IRCSink")
 fileprivate let mentionPattern = try! Regex(from: "<@.+?>")
 
 struct IRCSink: DefaultSink {
-    private let ircClient: IRCClient
+    private let client: IRCClient
 
     let name: String
 
-    init(ircClient: IRCClient, name: String) {
-        self.ircClient = ircClient
+    init(client: IRCClient, name: String) {
+        self.client = client
         self.name = name
     }
 
@@ -46,7 +46,7 @@ struct IRCSink: DefaultSink {
             return Promise(.failure(IRCSinkError.invalidChannelName(channelId.value)))
         }
 
-        ircClient.send(.PRIVMSG([.channel(channelName)], text))
+        client.send(.PRIVMSG([.channel(channelName)], text))
 
         return Promise(.success(message))
     }

--- a/Sources/D2IRCIO/IRCSink.swift
+++ b/Sources/D2IRCIO/IRCSink.swift
@@ -8,7 +8,7 @@ import Logging
 fileprivate let log = Logger(label: "D2IRCIO.IRCSink")
 fileprivate let mentionPattern = try! Regex(from: "<@.+?>")
 
-struct IRCSink: DefaultMessageIOSink {
+struct IRCSink: DefaultSink {
     private let ircClient: IRCClient
 
     let name: String

--- a/Sources/D2IRCIO/IRCSinkError.swift
+++ b/Sources/D2IRCIO/IRCSinkError.swift
@@ -1,0 +1,3 @@
+public enum IRCSinkError: Error {
+    case invalidChannelName(String)
+}

--- a/Sources/D2MessageIO/CombinedSink.swift
+++ b/Sources/D2MessageIO/CombinedSink.swift
@@ -4,174 +4,174 @@ import Logging
 
 fileprivate let log = Logger(label: "D2MessageIO.CombinedSink")
 
-/// A Sink that combines multiple clients and
-/// dispatches requests dynamically based on the ID's client name.
+/// A Sink that combines multiple sinks and
+/// dispatches requests dynamically based on the ID's sink name.
 public class CombinedSink: Sink {
-    private var clients: [String: any Sink] = [:]
+    private var sinks: [String: any Sink] = [:]
 
-    private let mioCommandClientName: String?
-    private var mioCommandClient: (any Sink)? { mioCommandClientName.flatMap { clients[$0] } }
+    private let mioCommandSinkName: String?
+    private var mioCommandSink: (any Sink)? { mioCommandSinkName.flatMap { sinks[$0] } }
 
     public var me: User? { nil }
     public var name: String { "Combined" }
-    public var guilds: [Guild]? { clients.values.flatMap { $0.guilds ?? [] } }
-    public var messageFetchLimit: Int? { clients.values.compactMap { $0.messageFetchLimit }.min() }
+    public var guilds: [Guild]? { sinks.values.flatMap { $0.guilds ?? [] } }
+    public var messageFetchLimit: Int? { sinks.values.compactMap { $0.messageFetchLimit }.min() }
 
-    // TODO: Support more than one client for global MIO commands
-    public init(mioCommandClientName: String? = nil) {
-        self.mioCommandClientName = mioCommandClientName
+    // TODO: Support more than one sink for global MIO commands
+    public init(mioCommandSinkName: String? = nil) {
+        self.mioCommandSinkName = mioCommandSinkName
     }
 
     @discardableResult
-    public func register(client: any Sink) -> any Sink {
-        clients[client.name] = client
-        return OverlaySink(inner: self, name: client.name, me: client.me)
+    public func register(sink: any Sink) -> any Sink {
+        sinks[sink.name] = sink
+        return OverlaySink(inner: self, name: sink.name, me: sink.me)
     }
 
-    private func withClient<T>(of id: ID, _ action: (any Sink) throws -> T?) rethrows -> T? {
-        if let client = clients[id.clientName] {
-            return try action(client)
+    private func withSink<T>(of id: ID, _ action: (any Sink) throws -> T?) rethrows -> T? {
+        if let sink = sinks[id.clientName] {
+            return try action(sink)
         } else {
-            log.warning("Could not find client with name `\(id.clientName)`. This is a bug and might result in unhandled callbacks.")
+            log.warning("Could not find sink with name `\(id.clientName)`. This is a bug and might result in unhandled callbacks.")
             return nil
         }
     }
 
     public func guild(for guildId: GuildID) -> Guild? {
-        withClient(of: guildId) { $0.guild(for: guildId) }
+        withSink(of: guildId) { $0.guild(for: guildId) }
     }
 
     public func channel(for channelId: ChannelID) -> Channel? {
-        withClient(of: channelId) { $0.channel(for: channelId) }
+        withSink(of: channelId) { $0.channel(for: channelId) }
     }
 
     public func setPresence(_ presence: PresenceUpdate) {
-        for client in clients.values {
-            client.setPresence(presence)
+        for sink in sinks.values {
+            sink.setPresence(presence)
         }
     }
 
     public func guildForChannel(_ channelId: ChannelID) -> Guild? {
-        withClient(of: channelId) { $0.guildForChannel(channelId) }
+        withSink(of: channelId) { $0.guildForChannel(channelId) }
     }
 
     public func permissionsForUser(_ userId: UserID, in channelId: ChannelID, on guildId: GuildID) -> Permissions {
-        withClient(of: channelId) { $0.permissionsForUser(userId, in: channelId, on: guildId) } ?? []
+        withSink(of: channelId) { $0.permissionsForUser(userId, in: channelId, on: guildId) } ?? []
     }
 
     public func avatarUrlForUser(_ userId: UserID, with avatarId: String, size: Int, preferredExtension: String?) -> URL? {
-        withClient(of: userId) { $0.avatarUrlForUser(userId, with: avatarId, size: size, preferredExtension: preferredExtension) }
+        withSink(of: userId) { $0.avatarUrlForUser(userId, with: avatarId, size: size, preferredExtension: preferredExtension) }
     }
 
     public func addGuildMemberRole(_ roleId: RoleID, to userId: UserID, on guildId: GuildID, reason: String?) -> Promise<Bool, any Error> {
-        withClient(of: roleId) { $0.addGuildMemberRole(roleId, to: userId, on: guildId, reason: reason) } ?? Promise(.success(false))
+        withSink(of: roleId) { $0.addGuildMemberRole(roleId, to: userId, on: guildId, reason: reason) } ?? Promise(.success(false))
     }
 
     public func removeGuildMemberRole(_ roleId: RoleID, from userId: UserID, on guildId: GuildID, reason: String?) -> Promise<Bool, any Error> {
-        withClient(of: roleId) { $0.removeGuildMemberRole(roleId, from: userId, on: guildId, reason: reason) } ?? Promise(.success(false))
+        withSink(of: roleId) { $0.removeGuildMemberRole(roleId, from: userId, on: guildId, reason: reason) } ?? Promise(.success(false))
     }
 
     public func createDM(with userId: UserID) -> Promise<ChannelID?, any Error> {
-        withClient(of: userId) { $0.createDM(with: userId) } ?? Promise(.success(nil))
+        withSink(of: userId) { $0.createDM(with: userId) } ?? Promise(.success(nil))
     }
 
     public func sendMessage(_ message: Message, to channelId: ChannelID) -> Promise<Message?, any Error> {
-        withClient(of: channelId) {
+        withSink(of: channelId) {
             log.info("Sending '\(message.content.truncated(to: 10, appending: "..."))' to \($0.name) channel \(channelId)")
             return $0.sendMessage(message, to: channelId)
         } ?? Promise(.success(nil))
     }
 
     public func editMessage(_ id: MessageID, on channelId: ChannelID, content: String) -> Promise<Message?, any Error> {
-        withClient(of: channelId) { $0.editMessage(id, on: channelId, content: content) } ?? Promise(.success(nil))
+        withSink(of: channelId) { $0.editMessage(id, on: channelId, content: content) } ?? Promise(.success(nil))
     }
 
     public func deleteMessage(_ id: MessageID, on channelId: ChannelID) -> Promise<Bool, any Error> {
-        withClient(of: channelId) { $0.deleteMessage(id, on: channelId) } ?? Promise(.success(false))
+        withSink(of: channelId) { $0.deleteMessage(id, on: channelId) } ?? Promise(.success(false))
     }
 
     public func bulkDeleteMessages(_ ids: [MessageID], on channelId: ChannelID) -> Promise<Bool, any Error> {
-        withClient(of: channelId) { $0.bulkDeleteMessages(ids, on: channelId) } ?? Promise(.success(false))
+        withSink(of: channelId) { $0.bulkDeleteMessages(ids, on: channelId) } ?? Promise(.success(false))
     }
 
     public func getMessages(for channelId: ChannelID, limit: Int, selection: MessageSelection?) -> Promise<[Message], any Error> {
-        withClient(of: channelId) { $0.getMessages(for: channelId, limit: limit, selection: selection) } ?? Promise(.success([]))
+        withSink(of: channelId) { $0.getMessages(for: channelId, limit: limit, selection: selection) } ?? Promise(.success([]))
     }
 
     public func modifyChannel(_ channelId: ChannelID, with modification: ChannelModification) -> Promise<Channel?, any Error> {
-        withClient(of: channelId) { $0.modifyChannel(channelId, with: modification) } ?? Promise(.success(nil))
+        withSink(of: channelId) { $0.modifyChannel(channelId, with: modification) } ?? Promise(.success(nil))
     }
 
     public func isGuildTextChannel(_ channelId: ChannelID) -> Promise<Bool, any Error> {
-        withClient(of: channelId) { $0.isGuildTextChannel(channelId) } ?? Promise(.success(false))
+        withSink(of: channelId) { $0.isGuildTextChannel(channelId) } ?? Promise(.success(false))
     }
 
     public func isDMTextChannel(_ channelId: ChannelID) -> Promise<Bool, any Error> {
-        withClient(of: channelId) { $0.isDMTextChannel(channelId) } ?? Promise(.success(false))
+        withSink(of: channelId) { $0.isDMTextChannel(channelId) } ?? Promise(.success(false))
     }
 
     public func triggerTyping(on channelId: ChannelID) -> Promise<Bool, any Error> {
-        withClient(of: channelId) { $0.triggerTyping(on: channelId) } ?? Promise(.success(false))
+        withSink(of: channelId) { $0.triggerTyping(on: channelId) } ?? Promise(.success(false))
     }
 
     public func createReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Promise<Message?, any Error> {
-        withClient(of: channelId) { $0.createReaction(for: messageId, on: channelId, emoji: emoji) } ?? Promise(.success(nil))
+        withSink(of: channelId) { $0.createReaction(for: messageId, on: channelId, emoji: emoji) } ?? Promise(.success(nil))
     }
 
     public func deleteOwnReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Promise<Bool, any Error> {
-        withClient(of: channelId) { $0.deleteOwnReaction(for: messageId, on: channelId, emoji: emoji) } ?? Promise(.success(false))
+        withSink(of: channelId) { $0.deleteOwnReaction(for: messageId, on: channelId, emoji: emoji) } ?? Promise(.success(false))
     }
 
     public func deleteUserReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String, by userId: UserID) -> Promise<Bool, any Error> {
-        withClient(of: channelId) { $0.deleteUserReaction(for: messageId, on: channelId, emoji: emoji, by: userId) } ?? Promise(.success(false))
+        withSink(of: channelId) { $0.deleteUserReaction(for: messageId, on: channelId, emoji: emoji, by: userId) } ?? Promise(.success(false))
     }
 
     public func createEmoji(on guildId: GuildID, name: String, image: String, roles: [RoleID]) -> Promise<Emoji?, any Error> {
-        withClient(of: guildId) { $0.createEmoji(on: guildId, name: name, image: image, roles: roles) } ?? Promise(.success(nil))
+        withSink(of: guildId) { $0.createEmoji(on: guildId, name: name, image: image, roles: roles) } ?? Promise(.success(nil))
     }
 
     public func deleteEmoji(from guildId: GuildID, emojiId: EmojiID) -> Promise<Bool, any Error> {
-        withClient(of: guildId) { $0.deleteEmoji(from: guildId, emojiId: emojiId) } ?? Promise(.success(false))
+        withSink(of: guildId) { $0.deleteEmoji(from: guildId, emojiId: emojiId) } ?? Promise(.success(false))
     }
 
     public func getMIOCommands() -> Promise<[MIOCommand], any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
-        return client.getMIOCommands()
+        guard let sink = mioCommandSink else { return Promise(.failure(SinkError.noMIOCommandSink)) }
+        return sink.getMIOCommands()
     }
 
     public func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
-        return client.createMIOCommand(name: name, description: description, options: options)
+        guard let sink = mioCommandSink else { return Promise(.failure(SinkError.noMIOCommandSink)) }
+        return sink.createMIOCommand(name: name, description: description, options: options)
     }
 
     public func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
-        return client.editMIOCommand(commandId, name: name, description: description, options: options)
+        guard let sink = mioCommandSink else { return Promise(.failure(SinkError.noMIOCommandSink)) }
+        return sink.editMIOCommand(commandId, name: name, description: description, options: options)
     }
 
     public func deleteMIOCommand(_ commandId: MIOCommandID) -> Promise<Bool, any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
-        return client.deleteMIOCommand(commandId)
+        guard let sink = mioCommandSink else { return Promise(.failure(SinkError.noMIOCommandSink)) }
+        return sink.deleteMIOCommand(commandId)
     }
 
     public func getMIOCommands(on guildId: GuildID) -> Promise<[MIOCommand], any Error> {
-        withClient(of: guildId) { $0.getMIOCommands(on: guildId) } ?? Promise(.failure(SinkError.noMIOCommandClient))
+        withSink(of: guildId) { $0.getMIOCommands(on: guildId) } ?? Promise(.failure(SinkError.noMIOCommandSink))
     }
 
     public func createMIOCommand(on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        withClient(of: guildId) { $0.createMIOCommand(on: guildId, name: name, description: description, options: options) } ?? Promise(.failure(SinkError.noMIOCommandClient))
+        withSink(of: guildId) { $0.createMIOCommand(on: guildId, name: name, description: description, options: options) } ?? Promise(.failure(SinkError.noMIOCommandSink))
     }
 
     public func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        withClient(of: guildId) { $0.editMIOCommand(commandId, on: guildId, name: name, description: description, options: options) } ?? Promise(.failure(SinkError.noMIOCommandClient))
+        withSink(of: guildId) { $0.editMIOCommand(commandId, on: guildId, name: name, description: description, options: options) } ?? Promise(.failure(SinkError.noMIOCommandSink))
     }
 
     public func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) -> Promise<Bool, any Error> {
-        withClient(of: guildId) { $0.deleteMIOCommand(commandId, on: guildId) } ?? Promise(.failure(SinkError.noMIOCommandClient))
+        withSink(of: guildId) { $0.deleteMIOCommand(commandId, on: guildId) } ?? Promise(.failure(SinkError.noMIOCommandSink))
     }
 
     public func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
-        return client.createInteractionResponse(for: interactionId, token: token, response: response)
+        guard let sink = mioCommandSink else { return Promise(.failure(SinkError.noMIOCommandSink)) }
+        return sink.createInteractionResponse(for: interactionId, token: token, response: response)
     }
 }

--- a/Sources/D2MessageIO/CombinedSink.swift
+++ b/Sources/D2MessageIO/CombinedSink.swift
@@ -2,15 +2,15 @@ import Foundation
 import Utils
 import Logging
 
-fileprivate let log = Logger(label: "D2MessageIO.CombinedMessageIOSink")
+fileprivate let log = Logger(label: "D2MessageIO.CombinedSink")
 
-/// A MessageIOSink that combines multiple clients and
+/// A Sink that combines multiple clients and
 /// dispatches requests dynamically based on the ID's client name.
-public class CombinedMessageIOSink: MessageIOSink {
-    private var clients: [String: any MessageIOSink] = [:]
+public class CombinedSink: Sink {
+    private var clients: [String: any Sink] = [:]
 
     private let mioCommandClientName: String?
-    private var mioCommandClient: (any MessageIOSink)? { mioCommandClientName.flatMap { clients[$0] } }
+    private var mioCommandClient: (any Sink)? { mioCommandClientName.flatMap { clients[$0] } }
 
     public var me: User? { nil }
     public var name: String { "Combined" }
@@ -23,12 +23,12 @@ public class CombinedMessageIOSink: MessageIOSink {
     }
 
     @discardableResult
-    public func register(client: any MessageIOSink) -> any MessageIOSink {
+    public func register(client: any Sink) -> any Sink {
         clients[client.name] = client
-        return OverlayMessageIOSink(inner: self, name: client.name, me: client.me)
+        return OverlaySink(inner: self, name: client.name, me: client.me)
     }
 
-    private func withClient<T>(of id: ID, _ action: (any MessageIOSink) throws -> T?) rethrows -> T? {
+    private func withClient<T>(of id: ID, _ action: (any Sink) throws -> T?) rethrows -> T? {
         if let client = clients[id.clientName] {
             return try action(client)
         } else {
@@ -135,43 +135,43 @@ public class CombinedMessageIOSink: MessageIOSink {
     }
 
     public func getMIOCommands() -> Promise<[MIOCommand], any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(MessageIOSinkError.noMIOCommandClient)) }
+        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
         return client.getMIOCommands()
     }
 
     public func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(MessageIOSinkError.noMIOCommandClient)) }
+        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
         return client.createMIOCommand(name: name, description: description, options: options)
     }
 
     public func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(MessageIOSinkError.noMIOCommandClient)) }
+        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
         return client.editMIOCommand(commandId, name: name, description: description, options: options)
     }
 
     public func deleteMIOCommand(_ commandId: MIOCommandID) -> Promise<Bool, any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(MessageIOSinkError.noMIOCommandClient)) }
+        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
         return client.deleteMIOCommand(commandId)
     }
 
     public func getMIOCommands(on guildId: GuildID) -> Promise<[MIOCommand], any Error> {
-        withClient(of: guildId) { $0.getMIOCommands(on: guildId) } ?? Promise(.failure(MessageIOSinkError.noMIOCommandClient))
+        withClient(of: guildId) { $0.getMIOCommands(on: guildId) } ?? Promise(.failure(SinkError.noMIOCommandClient))
     }
 
     public func createMIOCommand(on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        withClient(of: guildId) { $0.createMIOCommand(on: guildId, name: name, description: description, options: options) } ?? Promise(.failure(MessageIOSinkError.noMIOCommandClient))
+        withClient(of: guildId) { $0.createMIOCommand(on: guildId, name: name, description: description, options: options) } ?? Promise(.failure(SinkError.noMIOCommandClient))
     }
 
     public func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        withClient(of: guildId) { $0.editMIOCommand(commandId, on: guildId, name: name, description: description, options: options) } ?? Promise(.failure(MessageIOSinkError.noMIOCommandClient))
+        withClient(of: guildId) { $0.editMIOCommand(commandId, on: guildId, name: name, description: description, options: options) } ?? Promise(.failure(SinkError.noMIOCommandClient))
     }
 
     public func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) -> Promise<Bool, any Error> {
-        withClient(of: guildId) { $0.deleteMIOCommand(commandId, on: guildId) } ?? Promise(.failure(MessageIOSinkError.noMIOCommandClient))
+        withClient(of: guildId) { $0.deleteMIOCommand(commandId, on: guildId) } ?? Promise(.failure(SinkError.noMIOCommandClient))
     }
 
     public func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, any Error> {
-        guard let client = mioCommandClient else { return Promise(.failure(MessageIOSinkError.noMIOCommandClient)) }
+        guard let client = mioCommandClient else { return Promise(.failure(SinkError.noMIOCommandClient)) }
         return client.createInteractionResponse(for: interactionId, token: token, response: response)
     }
 }

--- a/Sources/D2MessageIO/DefaultMessageIOSink.swift
+++ b/Sources/D2MessageIO/DefaultMessageIOSink.swift
@@ -4,11 +4,11 @@ import Utils
 /// A message client that may implement its methods only partially.
 ///
 /// This is a separate protocol to ensure that message clients like
-/// `OverlayMessageClient` or `CombinedMessageClient` implement the
+/// `OverlayMessageIOSink` or `CombinedMessageIOSink` implement the
 /// full set of methods.
-public protocol DefaultMessageClient: MessageClient {}
+public protocol DefaultMessageIOSink: MessageIOSink {}
 
-public extension DefaultMessageClient {
+public extension DefaultMessageIOSink {
     var me: D2MessageIO.User? { nil }
     var messageFetchLimit: Int? { nil }
     var guilds: [Guild]? { nil }

--- a/Sources/D2MessageIO/DefaultSink.swift
+++ b/Sources/D2MessageIO/DefaultSink.swift
@@ -4,11 +4,11 @@ import Utils
 /// A message client that may implement its methods only partially.
 ///
 /// This is a separate protocol to ensure that message clients like
-/// `OverlayMessageIOSink` or `CombinedMessageIOSink` implement the
+/// `OverlaySink` or `CombinedSink` implement the
 /// full set of methods.
-public protocol DefaultMessageIOSink: MessageIOSink {}
+public protocol DefaultSink: Sink {}
 
-public extension DefaultMessageIOSink {
+public extension DefaultSink {
     var me: D2MessageIO.User? { nil }
     var messageFetchLimit: Int? { nil }
     var guilds: [Guild]? { nil }

--- a/Sources/D2MessageIO/MessageDelegate.swift
+++ b/Sources/D2MessageIO/MessageDelegate.swift
@@ -2,117 +2,117 @@ import Utils
 
 /// A handler for events from the message backend.
 public protocol MessageDelegate {
-    func on(connect connected: Bool, client: any Sink)
+    func on(connect connected: Bool, sink: any Sink)
 
-    func on(disconnectWithReason reason: String, client: any Sink)
+    func on(disconnectWithReason reason: String, sink: any Sink)
 
-    func on(createChannel channel: Channel, client: any Sink)
+    func on(createChannel channel: Channel, sink: any Sink)
 
-    func on(deleteChannel channel: Channel, client: any Sink)
+    func on(deleteChannel channel: Channel, sink: any Sink)
 
-    func on(updateChannel channel: Channel, client: any Sink)
+    func on(updateChannel channel: Channel, sink: any Sink)
 
-    func on(createThread thread: Channel, client: any Sink)
+    func on(createThread thread: Channel, sink: any Sink)
 
-    func on(deleteThread thread: Channel, client: any Sink)
+    func on(deleteThread thread: Channel, sink: any Sink)
 
-    func on(updateThread thread: Channel, client: any Sink)
+    func on(updateThread thread: Channel, sink: any Sink)
 
-    func on(createGuild guild: Guild, client: any Sink)
+    func on(createGuild guild: Guild, sink: any Sink)
 
-    func on(deleteGuild guild: Guild, client: any Sink)
+    func on(deleteGuild guild: Guild, sink: any Sink)
 
-    func on(updateGuild guild: Guild, client: any Sink)
+    func on(updateGuild guild: Guild, sink: any Sink)
 
-    func on(addGuildMember member: Guild.Member, client: any Sink)
+    func on(addGuildMember member: Guild.Member, sink: any Sink)
 
-    func on(removeGuildMember member: Guild.Member, client: any Sink)
+    func on(removeGuildMember member: Guild.Member, sink: any Sink)
 
-    func on(updateGuildMember member: Guild.Member, client: any Sink)
+    func on(updateGuildMember member: Guild.Member, sink: any Sink)
 
-    func on(updateMessage message: Message, client: any Sink)
+    func on(updateMessage message: Message, sink: any Sink)
 
-    func on(createMessage message: Message, client: any Sink)
+    func on(createMessage message: Message, sink: any Sink)
 
-    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink)
+    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink)
 
-    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink)
+    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink)
 
-    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any Sink)
+    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, sink: any Sink)
 
-    func on(createRole role: Role, on guild: Guild, client: any Sink)
+    func on(createRole role: Role, on guild: Guild, sink: any Sink)
 
-    func on(deleteRole role: Role, from guild: Guild, client: any Sink)
+    func on(deleteRole role: Role, from guild: Guild, sink: any Sink)
 
-    func on(updateRole role: Role, on guild: Guild, client: any Sink)
+    func on(updateRole role: Role, on guild: Guild, sink: any Sink)
 
-    func on(receivePresenceUpdate presence: Presence, client: any Sink)
+    func on(receivePresenceUpdate presence: Presence, sink: any Sink)
 
-    func on(createInteraction interaction: Interaction, client: any Sink)
+    func on(createInteraction interaction: Interaction, sink: any Sink)
 
-    func on(receiveReady data: [String: Any], client: any Sink)
+    func on(receiveReady data: [String: Any], sink: any Sink)
 
-    func on(receiveVoiceStateUpdate state: VoiceState, client: any Sink)
+    func on(receiveVoiceStateUpdate state: VoiceState, sink: any Sink)
 
-    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any Sink)
+    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, sink: any Sink)
 
-    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any Sink)
+    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, sink: any Sink)
 }
 
 public extension MessageDelegate {
-    func on(connect connected: Bool, client: any Sink) {}
+    func on(connect connected: Bool, sink: any Sink) {}
 
-    func on(disconnectWithReason reason: String, client: any Sink) {}
+    func on(disconnectWithReason reason: String, sink: any Sink) {}
 
-    func on(createChannel channel: Channel, client: any Sink) {}
+    func on(createChannel channel: Channel, sink: any Sink) {}
 
-    func on(deleteChannel channel: Channel, client: any Sink) {}
+    func on(deleteChannel channel: Channel, sink: any Sink) {}
 
-    func on(updateChannel channel: Channel, client: any Sink) {}
+    func on(updateChannel channel: Channel, sink: any Sink) {}
 
-    func on(createThread thread: Channel, client: any Sink) {}
+    func on(createThread thread: Channel, sink: any Sink) {}
 
-    func on(deleteThread thread: Channel, client: any Sink) {}
+    func on(deleteThread thread: Channel, sink: any Sink) {}
 
-    func on(updateThread thread: Channel, client: any Sink) {}
+    func on(updateThread thread: Channel, sink: any Sink) {}
 
-    func on(createGuild guild: Guild, client: any Sink) {}
+    func on(createGuild guild: Guild, sink: any Sink) {}
 
-    func on(deleteGuild guild: Guild, client: any Sink) {}
+    func on(deleteGuild guild: Guild, sink: any Sink) {}
 
-    func on(updateGuild guild: Guild, client: any Sink) {}
+    func on(updateGuild guild: Guild, sink: any Sink) {}
 
-    func on(addGuildMember member: Guild.Member, client: any Sink) {}
+    func on(addGuildMember member: Guild.Member, sink: any Sink) {}
 
-    func on(removeGuildMember member: Guild.Member, client: any Sink) {}
+    func on(removeGuildMember member: Guild.Member, sink: any Sink) {}
 
-    func on(updateGuildMember member: Guild.Member, client: any Sink) {}
+    func on(updateGuildMember member: Guild.Member, sink: any Sink) {}
 
-    func on(updateMessage message: Message, client: any Sink) {}
+    func on(updateMessage message: Message, sink: any Sink) {}
 
-    func on(createMessage message: Message, client: any Sink) {}
+    func on(createMessage message: Message, sink: any Sink) {}
 
-    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {}
+    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {}
 
-    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {}
+    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {}
 
-    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any Sink) {}
+    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, sink: any Sink) {}
 
-    func on(createRole role: Role, on guild: Guild, client: any Sink) {}
+    func on(createRole role: Role, on guild: Guild, sink: any Sink) {}
 
-    func on(deleteRole role: Role, from guild: Guild, client: any Sink) {}
+    func on(deleteRole role: Role, from guild: Guild, sink: any Sink) {}
 
-    func on(updateRole role: Role, on guild: Guild, client: any Sink) {}
+    func on(updateRole role: Role, on guild: Guild, sink: any Sink) {}
 
-    func on(receivePresenceUpdate presence: Presence, client: any Sink) {}
+    func on(receivePresenceUpdate presence: Presence, sink: any Sink) {}
 
-    func on(createInteraction interaction: Interaction, client: any Sink) {}
+    func on(createInteraction interaction: Interaction, sink: any Sink) {}
 
-    func on(receiveReady data: [String: Any], client: any Sink) {}
+    func on(receiveReady data: [String: Any], sink: any Sink) {}
 
-    func on(receiveVoiceStateUpdate state: VoiceState, client: any Sink) {}
+    func on(receiveVoiceStateUpdate state: VoiceState, sink: any Sink) {}
 
-    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any Sink) {}
+    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, sink: any Sink) {}
 
-    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any Sink) {}
+    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, sink: any Sink) {}
 }

--- a/Sources/D2MessageIO/MessageDelegate.swift
+++ b/Sources/D2MessageIO/MessageDelegate.swift
@@ -2,117 +2,117 @@ import Utils
 
 /// A handler for events from the message backend.
 public protocol MessageDelegate {
-    func on(connect connected: Bool, client: any MessageClient)
+    func on(connect connected: Bool, client: any MessageIOSink)
 
-    func on(disconnectWithReason reason: String, client: any MessageClient)
+    func on(disconnectWithReason reason: String, client: any MessageIOSink)
 
-    func on(createChannel channel: Channel, client: any MessageClient)
+    func on(createChannel channel: Channel, client: any MessageIOSink)
 
-    func on(deleteChannel channel: Channel, client: any MessageClient)
+    func on(deleteChannel channel: Channel, client: any MessageIOSink)
 
-    func on(updateChannel channel: Channel, client: any MessageClient)
+    func on(updateChannel channel: Channel, client: any MessageIOSink)
 
-    func on(createThread thread: Channel, client: any MessageClient)
+    func on(createThread thread: Channel, client: any MessageIOSink)
 
-    func on(deleteThread thread: Channel, client: any MessageClient)
+    func on(deleteThread thread: Channel, client: any MessageIOSink)
 
-    func on(updateThread thread: Channel, client: any MessageClient)
+    func on(updateThread thread: Channel, client: any MessageIOSink)
 
-    func on(createGuild guild: Guild, client: any MessageClient)
+    func on(createGuild guild: Guild, client: any MessageIOSink)
 
-    func on(deleteGuild guild: Guild, client: any MessageClient)
+    func on(deleteGuild guild: Guild, client: any MessageIOSink)
 
-    func on(updateGuild guild: Guild, client: any MessageClient)
+    func on(updateGuild guild: Guild, client: any MessageIOSink)
 
-    func on(addGuildMember member: Guild.Member, client: any MessageClient)
+    func on(addGuildMember member: Guild.Member, client: any MessageIOSink)
 
-    func on(removeGuildMember member: Guild.Member, client: any MessageClient)
+    func on(removeGuildMember member: Guild.Member, client: any MessageIOSink)
 
-    func on(updateGuildMember member: Guild.Member, client: any MessageClient)
+    func on(updateGuildMember member: Guild.Member, client: any MessageIOSink)
 
-    func on(updateMessage message: Message, client: any MessageClient)
+    func on(updateMessage message: Message, client: any MessageIOSink)
 
-    func on(createMessage message: Message, client: any MessageClient)
+    func on(createMessage message: Message, client: any MessageIOSink)
 
-    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient)
+    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink)
 
-    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient)
+    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink)
 
-    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any MessageClient)
+    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any MessageIOSink)
 
-    func on(createRole role: Role, on guild: Guild, client: any MessageClient)
+    func on(createRole role: Role, on guild: Guild, client: any MessageIOSink)
 
-    func on(deleteRole role: Role, from guild: Guild, client: any MessageClient)
+    func on(deleteRole role: Role, from guild: Guild, client: any MessageIOSink)
 
-    func on(updateRole role: Role, on guild: Guild, client: any MessageClient)
+    func on(updateRole role: Role, on guild: Guild, client: any MessageIOSink)
 
-    func on(receivePresenceUpdate presence: Presence, client: any MessageClient)
+    func on(receivePresenceUpdate presence: Presence, client: any MessageIOSink)
 
-    func on(createInteraction interaction: Interaction, client: any MessageClient)
+    func on(createInteraction interaction: Interaction, client: any MessageIOSink)
 
-    func on(receiveReady data: [String: Any], client: any MessageClient)
+    func on(receiveReady data: [String: Any], client: any MessageIOSink)
 
-    func on(receiveVoiceStateUpdate state: VoiceState, client: any MessageClient)
+    func on(receiveVoiceStateUpdate state: VoiceState, client: any MessageIOSink)
 
-    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any MessageClient)
+    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any MessageIOSink)
 
-    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any MessageClient)
+    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any MessageIOSink)
 }
 
 public extension MessageDelegate {
-    func on(connect connected: Bool, client: any MessageClient) {}
+    func on(connect connected: Bool, client: any MessageIOSink) {}
 
-    func on(disconnectWithReason reason: String, client: any MessageClient) {}
+    func on(disconnectWithReason reason: String, client: any MessageIOSink) {}
 
-    func on(createChannel channel: Channel, client: any MessageClient) {}
+    func on(createChannel channel: Channel, client: any MessageIOSink) {}
 
-    func on(deleteChannel channel: Channel, client: any MessageClient) {}
+    func on(deleteChannel channel: Channel, client: any MessageIOSink) {}
 
-    func on(updateChannel channel: Channel, client: any MessageClient) {}
+    func on(updateChannel channel: Channel, client: any MessageIOSink) {}
 
-    func on(createThread thread: Channel, client: any MessageClient) {}
+    func on(createThread thread: Channel, client: any MessageIOSink) {}
 
-    func on(deleteThread thread: Channel, client: any MessageClient) {}
+    func on(deleteThread thread: Channel, client: any MessageIOSink) {}
 
-    func on(updateThread thread: Channel, client: any MessageClient) {}
+    func on(updateThread thread: Channel, client: any MessageIOSink) {}
 
-    func on(createGuild guild: Guild, client: any MessageClient) {}
+    func on(createGuild guild: Guild, client: any MessageIOSink) {}
 
-    func on(deleteGuild guild: Guild, client: any MessageClient) {}
+    func on(deleteGuild guild: Guild, client: any MessageIOSink) {}
 
-    func on(updateGuild guild: Guild, client: any MessageClient) {}
+    func on(updateGuild guild: Guild, client: any MessageIOSink) {}
 
-    func on(addGuildMember member: Guild.Member, client: any MessageClient) {}
+    func on(addGuildMember member: Guild.Member, client: any MessageIOSink) {}
 
-    func on(removeGuildMember member: Guild.Member, client: any MessageClient) {}
+    func on(removeGuildMember member: Guild.Member, client: any MessageIOSink) {}
 
-    func on(updateGuildMember member: Guild.Member, client: any MessageClient) {}
+    func on(updateGuildMember member: Guild.Member, client: any MessageIOSink) {}
 
-    func on(updateMessage message: Message, client: any MessageClient) {}
+    func on(updateMessage message: Message, client: any MessageIOSink) {}
 
-    func on(createMessage message: Message, client: any MessageClient) {}
+    func on(createMessage message: Message, client: any MessageIOSink) {}
 
-    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {}
+    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {}
 
-    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageClient) {}
+    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {}
 
-    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any MessageClient) {}
+    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any MessageIOSink) {}
 
-    func on(createRole role: Role, on guild: Guild, client: any MessageClient) {}
+    func on(createRole role: Role, on guild: Guild, client: any MessageIOSink) {}
 
-    func on(deleteRole role: Role, from guild: Guild, client: any MessageClient) {}
+    func on(deleteRole role: Role, from guild: Guild, client: any MessageIOSink) {}
 
-    func on(updateRole role: Role, on guild: Guild, client: any MessageClient) {}
+    func on(updateRole role: Role, on guild: Guild, client: any MessageIOSink) {}
 
-    func on(receivePresenceUpdate presence: Presence, client: any MessageClient) {}
+    func on(receivePresenceUpdate presence: Presence, client: any MessageIOSink) {}
 
-    func on(createInteraction interaction: Interaction, client: any MessageClient) {}
+    func on(createInteraction interaction: Interaction, client: any MessageIOSink) {}
 
-    func on(receiveReady data: [String: Any], client: any MessageClient) {}
+    func on(receiveReady data: [String: Any], client: any MessageIOSink) {}
 
-    func on(receiveVoiceStateUpdate state: VoiceState, client: any MessageClient) {}
+    func on(receiveVoiceStateUpdate state: VoiceState, client: any MessageIOSink) {}
 
-    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any MessageClient) {}
+    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any MessageIOSink) {}
 
-    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any MessageClient) {}
+    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any MessageIOSink) {}
 }

--- a/Sources/D2MessageIO/MessageDelegate.swift
+++ b/Sources/D2MessageIO/MessageDelegate.swift
@@ -2,117 +2,117 @@ import Utils
 
 /// A handler for events from the message backend.
 public protocol MessageDelegate {
-    func on(connect connected: Bool, client: any MessageIOSink)
+    func on(connect connected: Bool, client: any Sink)
 
-    func on(disconnectWithReason reason: String, client: any MessageIOSink)
+    func on(disconnectWithReason reason: String, client: any Sink)
 
-    func on(createChannel channel: Channel, client: any MessageIOSink)
+    func on(createChannel channel: Channel, client: any Sink)
 
-    func on(deleteChannel channel: Channel, client: any MessageIOSink)
+    func on(deleteChannel channel: Channel, client: any Sink)
 
-    func on(updateChannel channel: Channel, client: any MessageIOSink)
+    func on(updateChannel channel: Channel, client: any Sink)
 
-    func on(createThread thread: Channel, client: any MessageIOSink)
+    func on(createThread thread: Channel, client: any Sink)
 
-    func on(deleteThread thread: Channel, client: any MessageIOSink)
+    func on(deleteThread thread: Channel, client: any Sink)
 
-    func on(updateThread thread: Channel, client: any MessageIOSink)
+    func on(updateThread thread: Channel, client: any Sink)
 
-    func on(createGuild guild: Guild, client: any MessageIOSink)
+    func on(createGuild guild: Guild, client: any Sink)
 
-    func on(deleteGuild guild: Guild, client: any MessageIOSink)
+    func on(deleteGuild guild: Guild, client: any Sink)
 
-    func on(updateGuild guild: Guild, client: any MessageIOSink)
+    func on(updateGuild guild: Guild, client: any Sink)
 
-    func on(addGuildMember member: Guild.Member, client: any MessageIOSink)
+    func on(addGuildMember member: Guild.Member, client: any Sink)
 
-    func on(removeGuildMember member: Guild.Member, client: any MessageIOSink)
+    func on(removeGuildMember member: Guild.Member, client: any Sink)
 
-    func on(updateGuildMember member: Guild.Member, client: any MessageIOSink)
+    func on(updateGuildMember member: Guild.Member, client: any Sink)
 
-    func on(updateMessage message: Message, client: any MessageIOSink)
+    func on(updateMessage message: Message, client: any Sink)
 
-    func on(createMessage message: Message, client: any MessageIOSink)
+    func on(createMessage message: Message, client: any Sink)
 
-    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink)
+    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink)
 
-    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink)
+    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink)
 
-    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any MessageIOSink)
+    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any Sink)
 
-    func on(createRole role: Role, on guild: Guild, client: any MessageIOSink)
+    func on(createRole role: Role, on guild: Guild, client: any Sink)
 
-    func on(deleteRole role: Role, from guild: Guild, client: any MessageIOSink)
+    func on(deleteRole role: Role, from guild: Guild, client: any Sink)
 
-    func on(updateRole role: Role, on guild: Guild, client: any MessageIOSink)
+    func on(updateRole role: Role, on guild: Guild, client: any Sink)
 
-    func on(receivePresenceUpdate presence: Presence, client: any MessageIOSink)
+    func on(receivePresenceUpdate presence: Presence, client: any Sink)
 
-    func on(createInteraction interaction: Interaction, client: any MessageIOSink)
+    func on(createInteraction interaction: Interaction, client: any Sink)
 
-    func on(receiveReady data: [String: Any], client: any MessageIOSink)
+    func on(receiveReady data: [String: Any], client: any Sink)
 
-    func on(receiveVoiceStateUpdate state: VoiceState, client: any MessageIOSink)
+    func on(receiveVoiceStateUpdate state: VoiceState, client: any Sink)
 
-    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any MessageIOSink)
+    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any Sink)
 
-    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any MessageIOSink)
+    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any Sink)
 }
 
 public extension MessageDelegate {
-    func on(connect connected: Bool, client: any MessageIOSink) {}
+    func on(connect connected: Bool, client: any Sink) {}
 
-    func on(disconnectWithReason reason: String, client: any MessageIOSink) {}
+    func on(disconnectWithReason reason: String, client: any Sink) {}
 
-    func on(createChannel channel: Channel, client: any MessageIOSink) {}
+    func on(createChannel channel: Channel, client: any Sink) {}
 
-    func on(deleteChannel channel: Channel, client: any MessageIOSink) {}
+    func on(deleteChannel channel: Channel, client: any Sink) {}
 
-    func on(updateChannel channel: Channel, client: any MessageIOSink) {}
+    func on(updateChannel channel: Channel, client: any Sink) {}
 
-    func on(createThread thread: Channel, client: any MessageIOSink) {}
+    func on(createThread thread: Channel, client: any Sink) {}
 
-    func on(deleteThread thread: Channel, client: any MessageIOSink) {}
+    func on(deleteThread thread: Channel, client: any Sink) {}
 
-    func on(updateThread thread: Channel, client: any MessageIOSink) {}
+    func on(updateThread thread: Channel, client: any Sink) {}
 
-    func on(createGuild guild: Guild, client: any MessageIOSink) {}
+    func on(createGuild guild: Guild, client: any Sink) {}
 
-    func on(deleteGuild guild: Guild, client: any MessageIOSink) {}
+    func on(deleteGuild guild: Guild, client: any Sink) {}
 
-    func on(updateGuild guild: Guild, client: any MessageIOSink) {}
+    func on(updateGuild guild: Guild, client: any Sink) {}
 
-    func on(addGuildMember member: Guild.Member, client: any MessageIOSink) {}
+    func on(addGuildMember member: Guild.Member, client: any Sink) {}
 
-    func on(removeGuildMember member: Guild.Member, client: any MessageIOSink) {}
+    func on(removeGuildMember member: Guild.Member, client: any Sink) {}
 
-    func on(updateGuildMember member: Guild.Member, client: any MessageIOSink) {}
+    func on(updateGuildMember member: Guild.Member, client: any Sink) {}
 
-    func on(updateMessage message: Message, client: any MessageIOSink) {}
+    func on(updateMessage message: Message, client: any Sink) {}
 
-    func on(createMessage message: Message, client: any MessageIOSink) {}
+    func on(createMessage message: Message, client: any Sink) {}
 
-    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {}
+    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {}
 
-    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any MessageIOSink) {}
+    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, client: any Sink) {}
 
-    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any MessageIOSink) {}
+    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, client: any Sink) {}
 
-    func on(createRole role: Role, on guild: Guild, client: any MessageIOSink) {}
+    func on(createRole role: Role, on guild: Guild, client: any Sink) {}
 
-    func on(deleteRole role: Role, from guild: Guild, client: any MessageIOSink) {}
+    func on(deleteRole role: Role, from guild: Guild, client: any Sink) {}
 
-    func on(updateRole role: Role, on guild: Guild, client: any MessageIOSink) {}
+    func on(updateRole role: Role, on guild: Guild, client: any Sink) {}
 
-    func on(receivePresenceUpdate presence: Presence, client: any MessageIOSink) {}
+    func on(receivePresenceUpdate presence: Presence, client: any Sink) {}
 
-    func on(createInteraction interaction: Interaction, client: any MessageIOSink) {}
+    func on(createInteraction interaction: Interaction, client: any Sink) {}
 
-    func on(receiveReady data: [String: Any], client: any MessageIOSink) {}
+    func on(receiveReady data: [String: Any], client: any Sink) {}
 
-    func on(receiveVoiceStateUpdate state: VoiceState, client: any MessageIOSink) {}
+    func on(receiveVoiceStateUpdate state: VoiceState, client: any Sink) {}
 
-    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any MessageIOSink) {}
+    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, client: any Sink) {}
 
-    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any MessageIOSink) {}
+    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, client: any Sink) {}
 }

--- a/Sources/D2MessageIO/MessageIOSink.swift
+++ b/Sources/D2MessageIO/MessageIOSink.swift
@@ -2,10 +2,10 @@ import Foundation
 import Logging
 import Utils
 
-fileprivate let log = Logger(label: "D2MessageIO.MessageClient")
+fileprivate let log = Logger(label: "D2MessageIO.MessageIOSink")
 
 /// An entry-point for commands sent to the message backend.
-public protocol MessageClient {
+public protocol MessageIOSink {
     var name: String { get }
     var me: User? { get }
     var guilds: [Guild]? { get }
@@ -102,7 +102,7 @@ public protocol MessageClient {
     func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, any Error>
 }
 
-public extension MessageClient {
+public extension MessageIOSink {
     func sendMessage(_ content: String, to channelId: ChannelID) {
         sendMessage(Message(content: content), to: channelId)
     }

--- a/Sources/D2MessageIO/MessageIOSinkError.swift
+++ b/Sources/D2MessageIO/MessageIOSinkError.swift
@@ -1,4 +1,4 @@
-public enum MessageClientError: Error {
+public enum MessageIOSinkError: Error {
     case couldNotFindClientWithName(String)
     case noMIOCommandClient
 }

--- a/Sources/D2MessageIO/MessagePlatform.swift
+++ b/Sources/D2MessageIO/MessagePlatform.swift
@@ -15,7 +15,7 @@ public protocol MessagePlatform: Startable {
     /// to block and to finish quickly.
     init(
         with delegate: any MessageDelegate,
-        combinedClient: CombinedMessageIOSink,
+        combinedClient: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token: Token
     ) throws

--- a/Sources/D2MessageIO/MessagePlatform.swift
+++ b/Sources/D2MessageIO/MessagePlatform.swift
@@ -15,7 +15,7 @@ public protocol MessagePlatform: Startable {
     /// to block and to finish quickly.
     init(
         with delegate: any MessageDelegate,
-        combinedClient: CombinedSink,
+        combinedSink: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token: Token
     ) throws

--- a/Sources/D2MessageIO/MessagePlatform.swift
+++ b/Sources/D2MessageIO/MessagePlatform.swift
@@ -15,7 +15,7 @@ public protocol MessagePlatform: Startable {
     /// to block and to finish quickly.
     init(
         with delegate: any MessageDelegate,
-        combinedClient: CombinedMessageClient,
+        combinedClient: CombinedMessageIOSink,
         eventLoopGroup: any EventLoopGroup,
         token: Token
     ) throws

--- a/Sources/D2MessageIO/MessagePlatform.swift
+++ b/Sources/D2MessageIO/MessagePlatform.swift
@@ -14,7 +14,7 @@ public protocol MessagePlatform: Startable {
     /// Performs synchronous setup. This method is expected not
     /// to block and to finish quickly.
     init(
-        with delegate: any MessageDelegate,
+        receiver: any Receiver,
         combinedSink: CombinedSink,
         eventLoopGroup: any EventLoopGroup,
         token: Token

--- a/Sources/D2MessageIO/OverlayMessageIOSink.swift
+++ b/Sources/D2MessageIO/OverlayMessageIOSink.swift
@@ -2,15 +2,15 @@ import Foundation
 import Utils
 
 /// A decorator message client that uses a custom 'name' and 'me'.
-public struct OverlayMessageClient: MessageClient {
-    private let inner: any MessageClient
+public struct OverlayMessageIOSink: MessageIOSink {
+    private let inner: any MessageIOSink
 
     public let name: String
     public let me: User?
     public var guilds: [Guild]? { inner.guilds }
     public var messageFetchLimit: Int? { inner.messageFetchLimit }
 
-    public init(inner: any MessageClient, name: String, me: User? = nil) {
+    public init(inner: any MessageIOSink, name: String, me: User? = nil) {
         self.inner = inner
         self.name = name
         self.me = me

--- a/Sources/D2MessageIO/OverlaySink.swift
+++ b/Sources/D2MessageIO/OverlaySink.swift
@@ -2,15 +2,15 @@ import Foundation
 import Utils
 
 /// A decorator message client that uses a custom 'name' and 'me'.
-public struct OverlayMessageIOSink: MessageIOSink {
-    private let inner: any MessageIOSink
+public struct OverlaySink: Sink {
+    private let inner: any Sink
 
     public let name: String
     public let me: User?
     public var guilds: [Guild]? { inner.guilds }
     public var messageFetchLimit: Int? { inner.messageFetchLimit }
 
-    public init(inner: any MessageIOSink, name: String, me: User? = nil) {
+    public init(inner: any Sink, name: String, me: User? = nil) {
         self.inner = inner
         self.name = name
         self.me = me

--- a/Sources/D2MessageIO/Receiver.swift
+++ b/Sources/D2MessageIO/Receiver.swift
@@ -1,7 +1,7 @@
 import Utils
 
 /// A handler for events from the message backend.
-public protocol MessageDelegate {
+public protocol Receiver {
     func on(connect connected: Bool, sink: any Sink)
 
     func on(disconnectWithReason reason: String, sink: any Sink)
@@ -59,7 +59,7 @@ public protocol MessageDelegate {
     func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, sink: any Sink)
 }
 
-public extension MessageDelegate {
+public extension Receiver {
     func on(connect connected: Bool, sink: any Sink) {}
 
     func on(disconnectWithReason reason: String, sink: any Sink) {}

--- a/Sources/D2MessageIO/Sink.swift
+++ b/Sources/D2MessageIO/Sink.swift
@@ -2,10 +2,10 @@ import Foundation
 import Logging
 import Utils
 
-fileprivate let log = Logger(label: "D2MessageIO.MessageIOSink")
+fileprivate let log = Logger(label: "D2MessageIO.Sink")
 
 /// An entry-point for commands sent to the message backend.
-public protocol MessageIOSink {
+public protocol Sink {
     var name: String { get }
     var me: User? { get }
     var guilds: [Guild]? { get }
@@ -102,7 +102,7 @@ public protocol MessageIOSink {
     func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, any Error>
 }
 
-public extension MessageIOSink {
+public extension Sink {
     func sendMessage(_ content: String, to channelId: ChannelID) {
         sendMessage(Message(content: content), to: channelId)
     }

--- a/Sources/D2MessageIO/SinkError.swift
+++ b/Sources/D2MessageIO/SinkError.swift
@@ -1,4 +1,4 @@
 public enum SinkError: Error {
     case couldNotFindClientWithName(String)
-    case noMIOCommandClient
+    case noMIOCommandSink
 }

--- a/Sources/D2MessageIO/SinkError.swift
+++ b/Sources/D2MessageIO/SinkError.swift
@@ -1,4 +1,4 @@
-public enum MessageIOSinkError: Error {
+public enum SinkError: Error {
     case couldNotFindClientWithName(String)
     case noMIOCommandClient
 }

--- a/Sources/D2MessageIO/utils/MessageIOClientConvertible.swift
+++ b/Sources/D2MessageIO/utils/MessageIOClientConvertible.swift
@@ -1,5 +1,5 @@
 public protocol MessageIOClientConvertible {
     associatedtype MessageIOType
 
-    func usingMessageIO(with client: any MessageIOSink) -> MessageIOType
+    func usingMessageIO(with client: any Sink) -> MessageIOType
 }

--- a/Sources/D2MessageIO/utils/MessageIOClientConvertible.swift
+++ b/Sources/D2MessageIO/utils/MessageIOClientConvertible.swift
@@ -1,5 +1,5 @@
 public protocol MessageIOClientConvertible {
     associatedtype MessageIOType
 
-    func usingMessageIO(with client: any MessageClient) -> MessageIOType
+    func usingMessageIO(with client: any MessageIOSink) -> MessageIOType
 }

--- a/Sources/D2MessageIO/utils/MessageIOClientConvertible.swift
+++ b/Sources/D2MessageIO/utils/MessageIOClientConvertible.swift
@@ -1,5 +1,5 @@
 public protocol MessageIOClientConvertible {
     associatedtype MessageIOType
 
-    func usingMessageIO(with client: any Sink) -> MessageIOType
+    func usingMessageIO(with sink: any Sink) -> MessageIOType
 }

--- a/Sources/D2MessageIO/wrappers/InteractiveTextChannel.swift
+++ b/Sources/D2MessageIO/wrappers/InteractiveTextChannel.swift
@@ -4,9 +4,9 @@ import Utils
 /// client reference.
 public struct InteractiveTextChannel {
     public let id: ChannelID
-    private let client: any MessageIOSink
+    private let client: any Sink
 
-    public init(id: ChannelID, client: any MessageIOSink) {
+    public init(id: ChannelID, client: any Sink) {
         self.id = id
         self.client = client
     }

--- a/Sources/D2MessageIO/wrappers/InteractiveTextChannel.swift
+++ b/Sources/D2MessageIO/wrappers/InteractiveTextChannel.swift
@@ -4,9 +4,9 @@ import Utils
 /// client reference.
 public struct InteractiveTextChannel {
     public let id: ChannelID
-    private let client: any MessageClient
+    private let client: any MessageIOSink
 
-    public init(id: ChannelID, client: any MessageClient) {
+    public init(id: ChannelID, client: any MessageIOSink) {
         self.id = id
         self.client = client
     }

--- a/Sources/D2MessageIO/wrappers/InteractiveTextChannel.swift
+++ b/Sources/D2MessageIO/wrappers/InteractiveTextChannel.swift
@@ -4,20 +4,20 @@ import Utils
 /// client reference.
 public struct InteractiveTextChannel {
     public let id: ChannelID
-    private let client: any Sink
+    private let sink: any Sink
 
-    public init(id: ChannelID, client: any Sink) {
+    public init(id: ChannelID, sink: any Sink) {
         self.id = id
-        self.client = client
+        self.sink = sink
     }
 
     @discardableResult
     public func send(_ message: Message) -> Promise<Message?, any Error> {
-        client.sendMessage(message, to: id)
+        sink.sendMessage(message, to: id)
     }
 
     @discardableResult
     public func triggerTyping() -> Promise<Bool, any Error> {
-        client.triggerTyping(on: id)
+        sink.triggerTyping(on: id)
     }
 }

--- a/Sources/D2NetAPIs/akinator/AkinatorSession.swift
+++ b/Sources/D2NetAPIs/akinator/AkinatorSession.swift
@@ -2,7 +2,7 @@ import Foundation
 import Utils
 import Logging
 
-// Ported from https://github.com/janniksam/Akinator.Api.Net/blob/master/Akinator.Api.Net/AkinatorClient.cs
+// Ported from https://github.com/janniksam/Akinator.Api.Net/blob/master/Akinator.Api.Net/Akinatorsink.cs
 // MIT-licensed, Copyright (c) 2019 Jannik
 
 fileprivate let jQuerySignature = "jQuery331023608747682107778"

--- a/Tests/D2HandlersTests/message/handler/SpamHandlerTests.swift
+++ b/Tests/D2HandlersTests/message/handler/SpamHandlerTests.swift
@@ -94,7 +94,7 @@ final class SpamHandlerTests: XCTestCase {
 
     private func spam(after interval: TimeInterval = 0) {
         timestamp += interval
-        let _ = handler.handle(message: Message(content: "@everyone", author: user, channelId: channelId, mentionEveryone: true, timestamp: timestamp), from: output)
+        let _ = handler.handle(message: Message(content: "@everyone", author: user, channelId: channelId, mentionEveryone: true, timestamp: timestamp), sink: output)
     }
 
     private func isWarned() -> Bool {

--- a/Tests/D2HandlersTests/message/handler/TriggerReactionHandlerTests.swift
+++ b/Tests/D2HandlersTests/message/handler/TriggerReactionHandlerTests.swift
@@ -27,7 +27,7 @@ final class TriggerReactionHandlers: XCTestCase {
             id: ID("Dummy Message")
         )
         output.messages.append(message)
-        _ = handler.handle(message: message, from: output)
+        _ = handler.handle(message: message, sink: output)
         return output.lastReactions.contains { $0.emoji.name == emoji }
     }
 }

--- a/Tests/D2TestUtils/CommandTestUtils.swift
+++ b/Tests/D2TestUtils/CommandTestUtils.swift
@@ -5,7 +5,7 @@ extension Command {
 	public func testInvoke(
 		with input: RichValue = .none,
 		output: any CommandOutput,
-		context: CommandContext = CommandContext(client: nil, registry: CommandRegistry(), message: Message(content: ""), commandPrefix: "", subscriptions: SubscriptionSet())
+		context: CommandContext = CommandContext(sink: nil, registry: CommandRegistry(), message: Message(content: ""), commandPrefix: "", subscriptions: SubscriptionSet())
 	) {
 		invoke(with: input, output: output, context: context)
 	}
@@ -13,7 +13,7 @@ extension Command {
 	public func testSubscriptionMessage(
 		with content: String,
 		output: any CommandOutput,
-		context: CommandContext = CommandContext(client: nil, registry: CommandRegistry(), message: Message(content: ""), commandPrefix: "", subscriptions: SubscriptionSet())
+		context: CommandContext = CommandContext(sink: nil, registry: CommandRegistry(), message: Message(content: ""), commandPrefix: "", subscriptions: SubscriptionSet())
 	) {
 		onSubscriptionMessage(with: content, output: output, context: context)
 	}

--- a/Tests/D2TestUtils/TestOutput.swift
+++ b/Tests/D2TestUtils/TestOutput.swift
@@ -3,7 +3,7 @@ import Utils
 import D2MessageIO
 @testable import D2Commands
 
-/// An implementation of CommandOutput and MessageIOSink
+/// An implementation of CommandOutput and Sink
 /// that writes all messages into an array.
 public class TestOutput {
     private var _messages = [Message]() {
@@ -60,7 +60,7 @@ extension TestOutput: CommandOutput {
     }
 }
 
-extension TestOutput: DefaultMessageIOSink {
+extension TestOutput: DefaultSink {
     public var name: String { "Test" }
 
     public func guild(for guildId: GuildID) -> Guild? {

--- a/Tests/D2TestUtils/TestOutput.swift
+++ b/Tests/D2TestUtils/TestOutput.swift
@@ -3,7 +3,7 @@ import Utils
 import D2MessageIO
 @testable import D2Commands
 
-/// An implementation of CommandOutput and MessageClient
+/// An implementation of CommandOutput and MessageIOSink
 /// that writes all messages into an array.
 public class TestOutput {
     private var _messages = [Message]() {
@@ -60,7 +60,7 @@ extension TestOutput: CommandOutput {
     }
 }
 
-extension TestOutput: DefaultMessageClient {
+extension TestOutput: DefaultMessageIOSink {
     public var name: String { "Test" }
 
     public func guild(for guildId: GuildID) -> Guild? {


### PR DESCRIPTION
Some of these abstractions were named confusingly, since their function slightly deviated from established conventions, e.g. the term "Delegate" known from Cocoa frameworks such as UIKit or AppKit was used as a generic handler interface and the term "Client" was used for a generic command sink. We'll clarify these terms by renaming:

- `MessageDelegate` -> `Receiver` for handling incoming events originating from the Message IO layer
- `MessageClient` -> `Sink` for handling outgoing commands flowing into the Message IO layer

Additionally, the platform-specific client wrappers are now moved into manager classes that directly implement the delegate interface, which is more in line with the established delegation pattern from Cocoa (i.e. own a strong reference and pass `self` as delegate).