### PR TITLE
Replace `dispatchMain` with a sleep loop

### DIFF
--- a/Sources/D2/D2.swift
+++ b/Sources/D2/D2.swift
@@ -150,8 +150,9 @@ struct D2: AsyncParsableCommand {
             }
         }
 
-        // Block the thread
-        log.info("Blocking the main thread")
-        dispatchMain()
+        // Keep the program running
+        while !Task.isCancelled {
+            try await Task.sleep(for: .seconds(1_000_000))
+        }
     }
 }


### PR DESCRIPTION
This fixes an issue where the main queue would appear "stuck" upon startup, likely because calling `dispatchMain` from an async/Swift Concurrency context is a bad idea.

Running a `Task.sleep` loop seems to be the recommended approach for server-side applications, see e.g.

- https://github.com/samalone/websocket-actor-system?tab=readme-ov-file#quick-start
- https://forums.swift.org/t/sanity-check-using-a-forever-while-loop-within-a-task-to-create-a-service/71204/2