### PR TITLE
Make `Sink` methods and a number of handlers async

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "D2",
-    platforms: [.macOS(.v13)],
+    platforms: [.macOS(.v14)],
     products: [
         .executable(name: "D2", targets: ["D2"]),
     ],

--- a/Sources/D2/D2.swift
+++ b/Sources/D2/D2.swift
@@ -137,7 +137,11 @@ struct D2: AsyncParsableCommand {
         // Register channel log output if needed
         if let logChannel = config?.log?.channel {
             await logOutput.register {
-                combinedSink.sendMessage($0, to: logChannel)
+                do {
+                    try await combinedSink.sendMessage($0, to: logChannel)
+                } catch {
+                    log.warning("Could not log to channel: \(error)")
+                }
             }
         }
 

--- a/Sources/D2Commands/Administration/RemoveAllMIOCommandsCommand.swift
+++ b/Sources/D2Commands/Administration/RemoveAllMIOCommandsCommand.swift
@@ -7,24 +7,22 @@ public class RemoveAllMIOCommandsCommand: VoidCommand {
 
     public init() {}
 
-    public func invoke(output: any CommandOutput, context: CommandContext) {
+    public func invoke(output: any CommandOutput, context: CommandContext) async {
         guard let sink = context.sink else {
-            output.append(errorText: "No client present")
+            await output.append(errorText: "No client present")
             return
         }
 
-        sink.getMIOCommands().listen {
-            do {
-                let mioCommands = try $0.get()
+        do {
+            let mioCommands = try await sink.getMIOCommands()
 
-                for mioCommand in mioCommands {
-                    sink.deleteMIOCommand(mioCommand.id)
-                }
-
-                output.append("Deleted \(mioCommands.count) MIO commands")
-            } catch {
-                output.append(error, errorText: "Could not fetch MIO commands")
+            for mioCommand in mioCommands {
+                try await sink.deleteMIOCommand(mioCommand.id)
             }
+
+            await output.append("Deleted \(mioCommands.count) MIO commands")
+        } catch {
+            await output.append(error, errorText: "Could not delete MIO commands")
         }
     }
 }

--- a/Sources/D2Commands/Emoji/DeleteEmojiCommand.swift
+++ b/Sources/D2Commands/Emoji/DeleteEmojiCommand.swift
@@ -10,27 +10,24 @@ public class DeleteEmojiCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
         guard let sink = context.sink, let guild = context.guild else {
-            output.append(errorText: "Please make sure that a client and a guild exists!")
+            await output.append(errorText: "Please make sure that a client and a guild exists!")
             return
         }
         guard !input.isEmpty else {
-            output.append(errorText: "Please mention an emoji name!")
+            await output.append(errorText: "Please mention an emoji name!")
             return
         }
         guard let emojiId = guild.emojis.values.filter({ $0.name == input }).compactMap(\.id).first else {
-            output.append(errorText: "No emoji with the given name `\(input)` found!")
+            await output.append(errorText: "No emoji with the given name `\(input)` found!")
             return
         }
 
-        sink.deleteEmoji(from: guild.id, emojiId: emojiId)
-            .listen {
-                if (try? $0.get()) ?? false {
-                    output.append("Successfully deleted emoji!")
-                } else {
-                    output.append(errorText: "Could not delete emoji")
-                }
-            }
+        if (try? await sink.deleteEmoji(from: guild.id, emojiId: emojiId)) ?? false {
+            await output.append("Successfully deleted emoji!")
+        } else {
+            await output.append(errorText: "Could not delete emoji")
+        }
     }
 }

--- a/Sources/D2Commands/Fun/NeverHaveIEverCommand.swift
+++ b/Sources/D2Commands/Fun/NeverHaveIEverCommand.swift
@@ -31,8 +31,10 @@ public class NeverHaveIEverCommand: StringCommand {
     public func onSuccessfullySent(context: CommandContext) {
         guard let messageId = context.message.id, let channelId = context.message.channelId else { return }
 
-        for emoji in ["🍹", "❌"] {
-            context.sink?.createReaction(for: messageId, on: channelId, emoji: emoji)
+        Task {
+            for emoji in ["🍹", "❌"] {
+                _ = try? await context.sink?.createReaction(for: messageId, on: channelId, emoji: emoji)
+            }
         }
     }
 }

--- a/Sources/D2Commands/Fun/PatCommand.swift
+++ b/Sources/D2Commands/Fun/PatCommand.swift
@@ -39,69 +39,67 @@ public class PatCommand: Command {
         self.inventoryManager = inventoryManager
     }
 
-    public func invoke(with input: RichValue, output: any CommandOutput, context: CommandContext) {
+    public func invoke(with input: RichValue, output: any CommandOutput, context: CommandContext) async {
         guard let user = input.asMentions?.first else {
-            output.append(errorText: "Please mention someone!")
+            await output.append(errorText: "Please mention someone!")
             return
         }
         guard let author = context.author else {
-            output.append(errorText: "No author")
+            await output.append(errorText: "No author")
             return
         }
         guard let avatarUrl = context.sink?.avatarUrlForUser(user.id, with: user.avatar, size: 128, preferredExtension: "png") else {
-            output.append(errorText: "Could not fetch avatar URL")
+            await output.append(errorText: "Could not fetch avatar URL")
             return
         }
 
-        context.channel?.triggerTyping()
+        _ = try? await context.channel?.triggerTyping()
 
-        Promise(.success(HTTPRequest(url: avatarUrl)))
-            .then { $0.runAsync() }
-            .listen {
-                do {
-                    let data = try $0.get()
-                    guard !data.isEmpty else {
-                        output.append(errorText: "No avatar available")
-                        return
+        do {
+            let request = HTTPRequest(url: avatarUrl)
+            let data = try await request.run()
+
+            guard !data.isEmpty else {
+                await output.append(errorText: "No avatar available")
+                return
+            }
+
+            let patHand = try CairoImage(pngFilePath: "Resources/Fun/patHand.png")
+            let avatarImage = try CairoImage(pngData: data)
+            let width = avatarImage.width
+            let height = avatarImage.height
+            let radiusSquared = (width * height) / 4
+            var gif = GIF(quantizingImage: avatarImage)
+
+            // Cut out round avatar
+            for y in 0..<height {
+                for x in 0..<width {
+                    let cx = x - (width / 2)
+                    let cy = y - (height / 2)
+                    if (cx * cx) + (cy * cy) > radiusSquared {
+                        avatarImage[y, x] = .transparent
                     }
-
-                    let patHand = try CairoImage(pngFilePath: "Resources/Fun/patHand.png")
-                    let avatarImage = try CairoImage(pngData: data)
-                    let width = avatarImage.width
-                    let height = avatarImage.height
-                    let radiusSquared = (width * height) / 4
-                    var gif = GIF(quantizingImage: avatarImage)
-
-                    // Cut out round avatar
-                    for y in 0..<height {
-                        for x in 0..<width {
-                            let cx = x - (width / 2)
-                            let cy = y - (height / 2)
-                            if (cx * cx) + (cy * cy) > radiusSquared {
-                                avatarImage[y, x] = .transparent
-                            }
-                        }
-                    }
-
-                    // Render the animation
-                    for i in 0..<self.frameCount {
-                        let frame = try CairoImage(width: width, height: height)
-                        let percent = Double(i) / Double(self.frameCount)
-                        let graphics = CairoContext(image: frame)
-
-                        graphics.draw(image: avatarImage)
-                        graphics.draw(image: patHand, at: self.patOffset + Vec2(y: self.patScale * (1 - abs(pow(2 * percent - 1, Double(self.patPower))))))
-
-                        gif.frames.append(.init(image: frame, delayTime: self.delayTime))
-                    }
-
-                    output.append(.gif(gif))
-
-                    // Place the pat in the recipient's inventory
-                    self.inventoryManager[user].append(item: .init(id: "pat-\(author.username)", name: "Pat by \(author.username)"), to: "Pats")
-                } catch {
-                    output.append(errorText: "The avatar could not be fetched \(error)")
                 }
             }
+
+            // Render the animation
+            for i in 0..<self.frameCount {
+                let frame = try CairoImage(width: width, height: height)
+                let percent = Double(i) / Double(self.frameCount)
+                let graphics = CairoContext(image: frame)
+
+                graphics.draw(image: avatarImage)
+                graphics.draw(image: patHand, at: self.patOffset + Vec2(y: self.patScale * (1 - abs(pow(2 * percent - 1, Double(self.patPower))))))
+
+                gif.frames.append(.init(image: frame, delayTime: self.delayTime))
+            }
+
+            await output.append(.gif(gif))
+
+            // Place the pat in the recipient's inventory
+            self.inventoryManager[user].append(item: .init(id: "pat-\(author.username)", name: "Pat by \(author.username)"), to: "Pats")
+        } catch {
+            await output.append(errorText: "The avatar could not be fetched \(error)")
+        }
     }
 }

--- a/Sources/D2Commands/Fun/WouldYouRatherCommand.swift
+++ b/Sources/D2Commands/Fun/WouldYouRatherCommand.swift
@@ -36,7 +36,10 @@ public class WouldYouRatherCommand: StringCommand {
 
     public func onSuccessfullySent(context: CommandContext) {
         guard let messageId = context.message.id, let channelId = context.message.channelId else { return }
-        context.sink?.createReaction(for: messageId, on: channelId, emoji: emojiA)
-        context.sink?.createReaction(for: messageId, on: channelId, emoji: emojiB)
+        // TODO: Remove once onSuccessfullySent is async
+        Task {
+            _ = try? await context.sink?.createReaction(for: messageId, on: channelId, emoji: emojiA)
+            _ = try? await context.sink?.createReaction(for: messageId, on: channelId, emoji: emojiB)
+        }
     }
 }

--- a/Sources/D2Commands/Game/GameCommand.swift
+++ b/Sources/D2Commands/Game/GameCommand.swift
@@ -190,14 +190,17 @@ public class GameCommand<G: Game>: Command {
         let output = BufferedOutput(output)
         var continueSubscription: Bool = true
 
-        // TODO: Ideally we would like to write
+        // TODO: The interaction between BufferedOutput and async/await is not
+        // ideal here. Ideally, we would like to perform an (awaited) flush in
+        // the deinitializer, but Swift does not seem to provide a way to do
+        // that. The next best solution would be something like this:
         //
         //     defer { await output.flush() }
         //
-        // to ensure that both all outputs are flushed and that they are
-        // available after e.g. the test awaited them. Unfortunately,
-        // Swift does not allow asynchronous defer blocks, so we have to
-        // manually guard scope exits.
+        // ...to ensure that both all outputs are flushed after the method
+        // exits, which is mostly important for tests. Unfortunately, Swift
+        // does not allow asynchronous defer blocks, so we have to manually
+        // guard scope exits.
 
         do {
             let params = ActionParameters(

--- a/Sources/D2Commands/Game/Wordle/SolveWordleCommand.swift
+++ b/Sources/D2Commands/Game/Wordle/SolveWordleCommand.swift
@@ -66,7 +66,10 @@ public class SolveWordleCommand: StringCommand {
         board.guesses.append(WordleBoard.Guess(word: word, clues: clues))
         boards[channelId] = board
 
-        context.channel?.triggerTyping()
+        // TODO: Remove once we asyncify onSubscriptionMessage
+        Task {
+            _ = try? await context.channel?.triggerTyping()
+        }
 
         let possibleSolutions = board.possibleSolutions
         let embed: Embed

--- a/Sources/D2Commands/Meta/PresenceCommand.swift
+++ b/Sources/D2Commands/Meta/PresenceCommand.swift
@@ -39,20 +39,24 @@ public class PresenceCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
         if let parsedArgs = try? argsPattern.firstMatch(in: input) {
             let activityType = parsedArgs.1!
             let status = parsedArgs.2 ?? .online
             let customText = String(parsedArgs.3)
 
             guard let sink = context.sink else {
-                output.append(errorText: "No client found")
+                await output.append(errorText: "No client found")
                 return
             }
 
-            sink.setPresence(PresenceUpdate(activities: [Presence.Activity(name: customText, type: activityType)], status: status))
+            do {
+                try await sink.setPresence(PresenceUpdate(activities: [Presence.Activity(name: customText, type: activityType)], status: status))
+            } catch {
+                await output.append(error, errorText: "Could not set presence")
+            }
         } else {
-            output.append(errorText: "Syntax: [\(activityTypes.keys.joined(separator: "|"))] [\(availableStatusTypes.joined(separator: "|"))]? [custom text]")
+            await output.append(errorText: "Syntax: [\(activityTypes.keys.joined(separator: "|"))] [\(availableStatusTypes.joined(separator: "|"))]? [custom text]")
         }
     }
 }

--- a/Sources/D2Commands/Misc/CycleThroughCommand.swift
+++ b/Sources/D2Commands/Misc/CycleThroughCommand.swift
@@ -14,32 +14,35 @@ public class CycleThroughCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
         guard !timer.isRunning else {
-            output.append(errorText: "Animation is already running.")
+            await output.append(errorText: "Animation is already running.")
             return
         }
 
         let frames = input.split(separator: " ")
 
         guard frames.count < 4 else {
-            output.append(errorText: "Too many frames.")
+            await output.append(errorText: "Too many frames.")
             return
         }
 
         guard let firstFrame = frames.first else {
-            output.append(errorText: "Cannot create empty animation.")
+            await output.append(errorText: "Cannot create empty animation.")
             return
         }
 
         let sink = context.sink!
         let channelId = context.channel!.id
 
-        sink.sendMessage(Message(content: String(firstFrame)), to: channelId).listenOrLogError { sentMessage in
-            self.timer.schedule(nTimes: self.loops * frames.count) { i, _ in
+        do {
+            let sentMessage = try await sink.sendMessage(Message(content: String(firstFrame)), to: channelId)
+            for i in 0..<(self.loops * frames.count) {
                 let frame = String(frames[i % frames.count])
-                sink.editMessage(sentMessage!.id!, on: channelId, content: frame)
+                try await sink.editMessage(sentMessage!.id!, on: channelId, content: frame)
             }
+        } catch {
+            await output.append(error, errorText: "Could not send/edit message")
         }
     }
 }

--- a/Sources/D2Commands/Misc/DebugWeatherReactionsCommand.swift
+++ b/Sources/D2Commands/Misc/DebugWeatherReactionsCommand.swift
@@ -12,17 +12,17 @@ public class DebugWeatherReactionsCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: CommandOutput, context: CommandContext) {
+    public func invoke(with input: String, output: CommandOutput, context: CommandContext) async {
         guard let sink = context.sink else {
-            output.append(errorText: "No client available")
+            await output.append(errorText: "No client available")
             return
         }
         guard let messageId = context.message.id else {
-            output.append(errorText: "No message id available")
+            await output.append(errorText: "No message id available")
             return
         }
         guard let channelId = context.channel?.id else {
-            output.append(errorText: "No channel id available")
+            await output.append(errorText: "No channel id available")
             return
         }
 
@@ -42,12 +42,16 @@ public class DebugWeatherReactionsCommand: StringCommand {
             (main: "mist", description: ""),
         ]
 
-        for weather in weathers {
-            if let emoji = OpenWeatherMapWeather.Weather.emojiFor(main: weather.main, description: weather.description) {
-                sink.createReaction(for: messageId, on: channelId, emoji: emoji)
-            } else {
-                log.warning("Weather \(weather) has no emoji representation")
+        do {
+            for weather in weathers {
+                if let emoji = OpenWeatherMapWeather.Weather.emojiFor(main: weather.main, description: weather.description) {
+                    try await sink.createReaction(for: messageId, on: channelId, emoji: emoji)
+                } else {
+                    log.warning("Weather \(weather) has no emoji representation")
+                }
             }
+        } catch {
+            await output.append(error, errorText: "Could not create weather reactions")
         }
     }
 }

--- a/Sources/D2Commands/Misc/EchoCommand.swift
+++ b/Sources/D2Commands/Misc/EchoCommand.swift
@@ -13,7 +13,7 @@ public class EchoCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
-        output.append(input)
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
+        await output.append(input)
     }
 }

--- a/Sources/D2Commands/Misc/PetitionCommand.swift
+++ b/Sources/D2Commands/Misc/PetitionCommand.swift
@@ -9,13 +9,13 @@ public class PetitionCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
         guard !input.isEmpty else {
-            output.append(errorText: "Please enter something!")
+            await output.append(errorText: "Please enter something!")
             return
         }
 
-        output.append(Embed(
+        await output.append(Embed(
             title: "Petition",
             description: input
         ))
@@ -24,6 +24,9 @@ public class PetitionCommand: StringCommand {
     public func onSuccessfullySent(context: CommandContext) {
         guard let messageId = context.message.id, let channelId = context.message.channelId else { return }
 
-        context.sink?.createReaction(for: messageId, on: channelId, emoji: "✍️")
+        // TODO: Remove once onSuccessfullySent is async
+        Task {
+            _ = try? await context.sink?.createReaction(for: messageId, on: channelId, emoji: "✍️")
+        }
     }
 }

--- a/Sources/D2Commands/Misc/SayCommand.swift
+++ b/Sources/D2Commands/Misc/SayCommand.swift
@@ -10,7 +10,11 @@ public class SayCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
-        context.channel?.send(Message(content: input, tts: true))
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
+        do {
+            try await context.channel?.send(Message(content: input, tts: true))
+        } catch {
+            await output.append(error, errorText: "Could not say anything")
+        }
     }
 }

--- a/Sources/D2Commands/Misc/SortByCommand.swift
+++ b/Sources/D2Commands/Misc/SortByCommand.swift
@@ -21,24 +21,27 @@ public class SortByCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
         guard let criterion = sortCriteria[input] else {
-            output.append(errorText: "Unrecognized sort criterion: \(input). Try using one of these: \(sortCriteria.keys)")
+            await output.append(errorText: "Unrecognized sort criterion: \(input). Try using one of these: \(sortCriteria.keys)")
             return
         }
         guard let channel = context.channel?.id else {
-            output.append(errorText: "No channel found for message")
+            await output.append(errorText: "No channel found for message")
             return
         }
 
-        context.sink?.getMessages(for: channel, limit: 80).listenOrLogError { messages in
+        do {
+            let messages = try await context.sink?.getMessages(for: channel, limit: 80) ?? []
             let sorted = messages.sorted(by: criterion)
-            output.append(Embed(
+            await output.append(Embed(
                 title: ":star: Top messages",
                 fields: Array(sorted
                     .map { Embed.Field(name: $0.author?.username ?? "Unknown Author", value: $0.content.nilIfEmpty ?? "No content") }
                     .prefix(10))
             ))
+        } catch {
+            await output.append(error, errorText: "Could not get messages")
         }
     }
 }

--- a/Sources/D2Commands/Misc/SpeedtestCommand.swift
+++ b/Sources/D2Commands/Misc/SpeedtestCommand.swift
@@ -9,15 +9,13 @@ public class SpeedtestCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
-        context.channel?.triggerTyping()
-        FastQuery().perform().listen {
-            do {
-                let speed = try $0.get()
-                output.append(String(format: "The network speed is %.2f Mbit/s", speed.megabitsPerSecond))
-            } catch {
-                output.append(error, errorText: "Could not fetch network speed")
-            }
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
+        _ = try? await context.channel?.triggerTyping()
+        do {
+            let speed = try await FastQuery().perform().get()
+            await output.append(String(format: "The network speed is %.2f Mbit/s", speed.megabitsPerSecond))
+        } catch {
+            await output.append(error, errorText: "Could not fetch network speed")
         }
     }
 }

--- a/Sources/D2Commands/Misc/TriggerTypingCommand.swift
+++ b/Sources/D2Commands/Misc/TriggerTypingCommand.swift
@@ -12,7 +12,11 @@ public class TriggerTypingCommand: Command {
 
     public init() {}
 
-    public func invoke(with input: RichValue, output: any CommandOutput, context: CommandContext) {
-        context.channel?.triggerTyping()
+    public func invoke(with input: RichValue, output: any CommandOutput, context: CommandContext) async {
+        do {
+            try await context.channel?.triggerTyping()
+        } catch {
+            await output.append(error, errorText: "Could not trigger typing indicator")
+        }
     }
 }

--- a/Sources/D2Commands/Music/FindKeyCommand.swift
+++ b/Sources/D2Commands/Music/FindKeyCommand.swift
@@ -12,10 +12,10 @@ public class FindKeyCommand: StringCommand {
 
     public init() {}
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
         guard !input.isEmpty,
               let notes = try? input.split(separator: " ").map({ try Note(parsing: String($0)) }) else {
-            output.append(errorText: info.helpText!)
+            await output.append(errorText: info.helpText!)
             return
         }
 
@@ -26,6 +26,6 @@ public class FindKeyCommand: StringCommand {
                 MinorScale(key: Note(noteClass: key, octave: 0)),
             ] }
             .filter { noteClasses.isSubset(of: $0.notes.map(\.noteClass)) }
-        output.append("Possible keys: \(scales.map(\.abbreviatedClassName).joined(separator: " "))")
+        await output.append("Possible keys: \(scales.map(\.abbreviatedClassName).joined(separator: " "))")
     }
 }

--- a/Sources/D2Commands/Output/MessageIOInteractionOutput.swift
+++ b/Sources/D2Commands/Output/MessageIOInteractionOutput.swift
@@ -31,22 +31,22 @@ public class MessageIOInteractionOutput: CommandOutput {
         // TODO: Split/limit?
         do {
             let message = try await messageWriter.write(value: value)
-            _ = try await self.send(message: message, with: sink, to: channel).get()
+            _ = try await self.send(message: message, with: sink, to: channel)
         } catch {
             log.error("Interaction output failed: \(error)")
         }
     }
 
-    private func send(message: Message, with sink: any Sink, to channel: OutputChannel) -> Promise<Bool, any Error> {
+    private func send(message: Message, with sink: any Sink, to channel: OutputChannel) async throws -> Bool {
         switch channel {
             case .defaultChannel:
                 guard let token = interaction.token else {
-                    return Promise(.failure(MessageIOInteractionOutputError.noInteractionToken))
+                    throw MessageIOInteractionOutputError.noInteractionToken
                 }
                 let response = InteractionResponse(type: .channelMessageWithSource, data: message)
-                return sink.createInteractionResponse(for: interaction.id, token: token, response: response)
+                return try await sink.createInteractionResponse(for: interaction.id, token: token, response: response)
             default:
-                return Promise(.failure(MessageIOInteractionOutputError.onlyDefaultChannelSupported))
+                throw MessageIOInteractionOutputError.onlyDefaultChannelSupported
         }
     }
 

--- a/Sources/D2Commands/Scripting/AddEventListenerCommand.swift
+++ b/Sources/D2Commands/Scripting/AddEventListenerCommand.swift
@@ -20,20 +20,20 @@ public class AddEventListenerCommand: StringCommand {
         self.eventListenerBus = eventListenerBus
     }
 
-    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) {
+    public func invoke(with input: String, output: any CommandOutput, context: CommandContext) async {
         if let parsedArgs = try? argsPattern.firstMatch(in: input) {
             let rawEventName = String(parsedArgs.event)
             let listenerName = String(parsedArgs.listener)
 
             guard let event = EventListenerBus.Event(rawValue: rawEventName) else {
-                output.append(errorText: "Unknown event `\(rawEventName)`, try one of these: `\(EventListenerBus.Event.allCases.map { $0.rawValue })`")
+                await output.append(errorText: "Unknown event `\(rawEventName)`, try one of these: `\(EventListenerBus.Event.allCases.map { $0.rawValue })`")
                 return
             }
 
             eventListenerBus.addListener(name: listenerName, for: event, output: output)
-            context.channel?.send(Message(content: "Added event listener!"))
+            _ = try? await context.channel?.send(Message(content: "Added event listener!"))
         } else {
-            output.append(errorText: info.helpText!)
+            await output.append(errorText: info.helpText!)
         }
     }
 }

--- a/Sources/D2Commands/Scripting/LastMessageCommand.swift
+++ b/Sources/D2Commands/Scripting/LastMessageCommand.swift
@@ -22,7 +22,7 @@ public class LastMessageCommand: Command {
 
     public func invoke(with input: RichValue, output: any CommandOutput, context: CommandContext) async {
         do {
-            let messages = try await context.sink?.getMessages(for: context.channel!.id, limit: 2).get()
+            let messages = try await context.sink?.getMessages(for: context.channel!.id, limit: 2)
             guard let message = messages?[safely: 1] else {
                 throw LastMessageError.noLastMessage
             }

--- a/Sources/D2DiscordIO/DiscordSink.swift
+++ b/Sources/D2DiscordIO/DiscordSink.swift
@@ -57,210 +57,210 @@ struct DiscordSink: DefaultSink {
         return components.url
     }
 
-    func addGuildMemberRole(_ roleId: D2MessageIO.RoleID, to userId: D2MessageIO.UserID, on guildId: D2MessageIO.GuildID, reason: String?) -> Promise<Bool, any Error> {
-        Promise { then in
+    func addGuildMemberRole(_ roleId: D2MessageIO.RoleID, to userId: D2MessageIO.UserID, on guildId: D2MessageIO.GuildID, reason: String?) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.addGuildMemberRole(roleId.usingDiscordAPI, to: userId.usingDiscordAPI, on: guildId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func removeGuildMemberRole(_ roleId: D2MessageIO.RoleID, from userId: D2MessageIO.UserID, on guildId: D2MessageIO.GuildID, reason: String?) -> Promise<Bool, any Error> {
-        Promise { then in
+    func removeGuildMemberRole(_ roleId: D2MessageIO.RoleID, from userId: D2MessageIO.UserID, on guildId: D2MessageIO.GuildID, reason: String?) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.removeGuildMemberRole(roleId.usingDiscordAPI, from: userId.usingDiscordAPI, on: guildId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func createDM(with userId: D2MessageIO.UserID) -> Promise<D2MessageIO.ChannelID?, any Error> {
-        Promise { then in
+    func createDM(with userId: D2MessageIO.UserID) async throws -> D2MessageIO.ChannelID? {
+        try await withCheckedThrowingContinuation { continuation in
             client.createDM(with: userId.usingDiscordAPI) {
-                then(Result.from($0?.id.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0?.id.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func sendMessage(_ message: Message, to channelId: D2MessageIO.ChannelID) -> Promise<Message?, any Error> {
-        Promise { then in
+    func sendMessage(_ message: Message, to channelId: D2MessageIO.ChannelID) async throws -> Message? {
+        try await withCheckedThrowingContinuation { continuation in
             client.sendMessage(message.usingDiscordAPI, to: channelId.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO(with: self), errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0?.usingMessageIO(with: self), errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func editMessage(_ id: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, content: String) -> Promise<Message?, any Error> {
-        Promise { then in
+    func editMessage(_ id: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, content: String) async throws -> Message? {
+        try await withCheckedThrowingContinuation { continuation in
             client.editMessage(id.usingDiscordAPI, on: channelId.usingDiscordAPI, content: content) {
-                then(Result.from($0?.usingMessageIO(with: self), errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0?.usingMessageIO(with: self), errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func deleteMessage(_ id: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
-        Promise { then in
+    func deleteMessage(_ id: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.deleteMessage(id.usingDiscordAPI, on: channelId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func bulkDeleteMessages(_ ids: [D2MessageIO.MessageID], on channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
-        Promise { then in
+    func bulkDeleteMessages(_ ids: [D2MessageIO.MessageID], on channelId: D2MessageIO.ChannelID) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.bulkDeleteMessages(ids.map { $0.usingDiscordAPI }, on: channelId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func getMessages(for channelId: D2MessageIO.ChannelID, limit: Int, selection: MessageSelection?) -> Promise<[Message], any Error> {
-        Promise { then in
+    func getMessages(for channelId: D2MessageIO.ChannelID, limit: Int, selection: MessageSelection?) async throws -> [Message] {
+        try await withCheckedThrowingContinuation { continuation in
             client.getMessages(for: channelId.usingDiscordAPI, selection: selection?.usingDiscordAPI, limit: limit) {
-                then(Result.from($0.map { $0.usingMessageIO(with: self) }, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0.map { $0.usingMessageIO(with: self) }, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func modifyChannel(_ channelId: D2MessageIO.ChannelID, with modification: ChannelModification) -> Promise<Channel?, any Error> {
-        Promise { then in
+    func modifyChannel(_ channelId: D2MessageIO.ChannelID, with modification: ChannelModification) async throws -> Channel? {
+        try await withCheckedThrowingContinuation { continuation in
             client.modifyChannel(channelId.usingDiscordAPI, options: modification.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func isGuildTextChannel(_ channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
-        Promise { then in
+    func isGuildTextChannel(_ channelId: D2MessageIO.ChannelID) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.getChannel(channelId.usingDiscordAPI) {
-                then(Result.from($0.map { $0.type == .text } ?? false, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0.map { $0.type == .text } ?? false, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func isDMTextChannel(_ channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
-        Promise { then in
+    func isDMTextChannel(_ channelId: D2MessageIO.ChannelID) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.getChannel(channelId.usingDiscordAPI) {
-                then(Result.from($0.map(\.isDM) ?? false, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0.map(\.isDM) ?? false, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func triggerTyping(on channelId: D2MessageIO.ChannelID) -> Promise<Bool, any Error> {
-        Promise { then in
+    func triggerTyping(on channelId: D2MessageIO.ChannelID) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.triggerTyping(on: channelId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func createReaction(for messageId: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, emoji: String) -> Promise<Message?, any Error> {
-        Promise { then in
+    func createReaction(for messageId: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, emoji: String) async throws -> Message? {
+        await withCheckedContinuation { continuation in
             client.createReaction(for: messageId.usingDiscordAPI, on: channelId.usingDiscordAPI, emoji: emoji) { m, _ in
-                then(.success(m?.usingMessageIO(with: self)))
+                continuation.resume(returning: m?.usingMessageIO(with: self))
             }
         }
     }
 
-    func deleteOwnReaction(for messageId: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, emoji: String) -> Promise<Bool, any Error> {
-        Promise { then in
+    func deleteOwnReaction(for messageId: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, emoji: String) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.deleteOwnReaction(for: messageId.usingDiscordAPI, on: channelId.usingDiscordAPI, emoji: emoji) {
-                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func deleteUserReaction(for messageId: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, emoji: String, by userId: D2MessageIO.UserID) -> Promise<Bool, any Error> {
-        Promise { then in
+    func deleteUserReaction(for messageId: D2MessageIO.MessageID, on channelId: D2MessageIO.ChannelID, emoji: String, by userId: D2MessageIO.UserID) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.deleteUserReaction(for: messageId.usingDiscordAPI, on: channelId.usingDiscordAPI, emoji: emoji, by: userId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func createEmoji(on guildId: D2MessageIO.GuildID, name: String, image: String, roles: [D2MessageIO.RoleID]) -> Promise<Emoji?, any Error> {
-        Promise { then in
+    func createEmoji(on guildId: D2MessageIO.GuildID, name: String, image: String, roles: [D2MessageIO.RoleID]) async throws -> Emoji? {
+        try await withCheckedThrowingContinuation { continuation in
             client.createGuildEmoji(on: guildId.usingDiscordAPI, name: name, image: image, roles: roles.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func deleteEmoji(from guildId: D2MessageIO.GuildID, emojiId: D2MessageIO.EmojiID) -> Promise<Bool, any Error> {
-        Promise { then in
+    func deleteEmoji(from guildId: D2MessageIO.GuildID, emojiId: D2MessageIO.EmojiID) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.deleteGuildEmoji(on: guildId.usingDiscordAPI, for: emojiId.usingDiscordAPI) {
-                then(Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func getMIOCommands() -> Promise<[MIOCommand], any Error> {
-        Promise { then in
+    func getMIOCommands() async throws -> [MIOCommand] {
+        await withCheckedContinuation { continuation in
             client.getApplicationCommands { cs, _ in
-                then(.success(cs.usingMessageIO))
+                continuation.resume(returning: cs.usingMessageIO)
             }
         }
     }
 
-    func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        Promise { then in
+    func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
+        try await withCheckedThrowingContinuation { continuation in
             client.createApplicationCommand(name: name, description: description, options: options?.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        Promise { then in
+    func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
+        try await withCheckedThrowingContinuation { continuation in
             client.editApplicationCommand(commandId.usingDiscordAPI, name: name, description: description, options: options?.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func deleteMIOCommand(_ commandId: MIOCommandID) -> Promise<Bool, any Error> {
-        Promise { then in
+    func deleteMIOCommand(_ commandId: MIOCommandID) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.deleteApplicationCommand(commandId.usingDiscordAPI) {
-                then(Result.from($0 != nil, errorIfNil: DiscordSinkError.invalidResponse($0)))
+                continuation.resume(with: Result.from($0 != nil, errorIfNil: DiscordSinkError.invalidResponse($0)))
             }
         }
     }
 
-    func getMIOCommands(on guildId: D2MessageIO.GuildID) -> Promise<[MIOCommand], any Error> {
-        Promise { then in
+    func getMIOCommands(on guildId: D2MessageIO.GuildID) async throws -> [MIOCommand] {
+        await withCheckedContinuation { continuation in
             client.getApplicationCommands(on: guildId.usingDiscordAPI) { cs, _ in
-                then(.success(cs.usingMessageIO))
+                continuation.resume(returning: cs.usingMessageIO)
             }
         }
     }
 
-    func createMIOCommand(on guildId: D2MessageIO.GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        Promise { then in
+    func createMIOCommand(on guildId: D2MessageIO.GuildID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
+        try await withCheckedThrowingContinuation { continuation in
             client.createApplicationCommand(on: guildId.usingDiscordAPI, name: name, description: description, options: options?.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func editMIOCommand(_ commandId: MIOCommandID, on guildId: D2MessageIO.GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        Promise { then in
+    func editMIOCommand(_ commandId: MIOCommandID, on guildId: D2MessageIO.GuildID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
+        try await withCheckedThrowingContinuation { continuation in
             client.editApplicationCommand(commandId.usingDiscordAPI, on: guildId.usingDiscordAPI, name: name, description: description, options: options?.usingDiscordAPI) {
-                then(Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
+                continuation.resume(with: Result.from($0?.usingMessageIO, errorIfNil: DiscordSinkError.invalidResponse($1)))
             }
         }
     }
 
-    func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: D2MessageIO.GuildID) -> Promise<Bool, any Error> {
-        Promise { then in
+    func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: D2MessageIO.GuildID) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.deleteApplicationCommand(commandId.usingDiscordAPI, on: guildId.usingDiscordAPI) {
-                then(Result.from($0 != nil, errorIfNil: DiscordSinkError.invalidResponse($0)))
+                continuation.resume(with: Result.from($0 != nil, errorIfNil: DiscordSinkError.invalidResponse($0)))
             }
         }
     }
 
-    func createInteractionResponse(for interactionId: D2MessageIO.InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, any Error> {
-        Promise { then in
+    func createInteractionResponse(for interactionId: D2MessageIO.InteractionID, token: String, response: InteractionResponse) async throws -> Bool {
+        try await withCheckedThrowingContinuation { continuation in
             client.createInteractionResponse(for: interactionId.usingDiscordAPI, token: token, response: response.usingDiscordAPI) {
-                then(Result.from($0 != nil, errorIfNil: DiscordSinkError.invalidResponse($0)))
+                continuation.resume(with: Result.from($0 != nil, errorIfNil: DiscordSinkError.invalidResponse($0)))
             }
         }
     }

--- a/Sources/D2Handlers/Channel/Handler/ThreadKeepaliveHandler.swift
+++ b/Sources/D2Handlers/Channel/Handler/ThreadKeepaliveHandler.swift
@@ -12,7 +12,7 @@ public struct ThreadKeepaliveHandler: ChannelHandler {
         self._config = _config
     }
 
-    public func handle(threadUpdate thread: Channel, sink: any Sink) {
+    public func handle(threadUpdate thread: Channel, sink: any Sink) async {
         log.info("Thread \(thread.name) has archival status: \(thread.threadMetadata?.archived ?? false)")
 
         let archived = thread.threadMetadata?.archived ?? false
@@ -33,7 +33,11 @@ public struct ThreadKeepaliveHandler: ChannelHandler {
             }
 
             log.info("Unarchiving '\(thread.name)'")
-            sink.modifyChannel(thread.id, with: .init(archived: false))
+            do {
+                try await sink.modifyChannel(thread.id, with: .init(archived: false))
+            } catch {
+                log.error("Could not modify channel: \(error)")
+            }
         }
     }
 }

--- a/Sources/D2Handlers/Message/Handler/CountToNHandler.swift
+++ b/Sources/D2Handlers/Message/Handler/CountToNHandler.swift
@@ -1,14 +1,20 @@
 import D2Commands
 import D2MessageIO
+import Logging
 import Utils
 
 fileprivate let countToNPattern = #/count\s+to\s+(?<n>\d+)/#
+fileprivate let log = Logger(label: "D2Handlers.CountToNHandler")
 
 public struct CountToNHandler: MessageHandler {
-    public func handle(message: Message, sink: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) async throws -> Bool {
         if let parsed = try? countToNPattern.firstMatch(in: message.content.lowercased()), let n = UInt(parsed.n), n <= 300, let channelId = message.channelId {
-            sink.sendMessage(Message(content: "Here you go: \((1...n).map(String.init).joined(separator: ", "))"), to: channelId)
-            return true
+            do {
+                try await sink.sendMessage(Message(content: "Here you go: \((1...n).map(String.init).joined(separator: ", "))"), to: channelId)
+                return true
+            } catch {
+                log.warning("Could not send count-to-\(n) message: \(error)")
+            }
         }
         return false
     }

--- a/Sources/D2Handlers/Message/Handler/FactorialHandler.swift
+++ b/Sources/D2Handlers/Message/Handler/FactorialHandler.swift
@@ -1,7 +1,9 @@
 import Utils
+import Logging
 import D2MessageIO
 
 fileprivate let factorialPattern = #/\b(?<operand>\d+)!\b/#
+fileprivate let log = Logger(label: "D2Handlers.FactorialHandler")
 
 public struct FactorialHandler: MessageHandler {
     private let operandRange: Range<Int>
@@ -10,7 +12,7 @@ public struct FactorialHandler: MessageHandler {
         self.operandRange = operandRange
     }
 
-    public func handle(message: Message, sink: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) async -> Bool {
         if let channelId = message.channelId,
            let author = message.author,
            !author.bot {
@@ -20,7 +22,11 @@ public struct FactorialHandler: MessageHandler {
                let operand = Int(match.operand),
                operandRange.contains(operand) {
                 let result = factorial(operand)
-                sink.sendMessage("\(operand)! = \(result.isLessThanOrEqualTo(Double(Int.max)) ? String(Int(result)) : String(result))", to: channelId)
+                do {
+                    try await sink.sendMessage("\(operand)! = \(result.isLessThanOrEqualTo(Double(Int.max)) ? String(Int(result)) : String(result))", to: channelId)
+                } catch {
+                    log.warning("Could not send factorial message: \(error)")
+                }
             }
         }
         return false

--- a/Sources/D2Handlers/Message/Handler/HaikuHandler.swift
+++ b/Sources/D2Handlers/Message/Handler/HaikuHandler.swift
@@ -22,7 +22,7 @@ public struct HaikuHandler: MessageHandler {
         self.inventoryManager = inventoryManager
     }
 
-    public func handle(message: Message, sink: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) async -> Bool {
         if let channelId = message.channelId,
             configuration.enabledChannelIds.contains(channelId),
             let author = message.guildMember,
@@ -38,10 +38,14 @@ public struct HaikuHandler: MessageHandler {
             )
             inventoryManager[author.user].append(item: item, to: "Haikus")
 
-            sink.sendMessage(Message(embed: Embed(
-                title: "A Haiku by `\(author.displayName)`",
-                description: haiku.joined(separator: "\n")
-            )), to: channelId)
+            do {
+                try await sink.sendMessage(Message(embed: Embed(
+                    title: "A Haiku by `\(author.displayName)`",
+                    description: haiku.joined(separator: "\n")
+                )), to: channelId)
+            } catch {
+                log.warning("Could not send haiku message: \(error)")
+            }
         }
         return false
     }

--- a/Sources/D2Handlers/Message/Handler/MentionD2Handler.swift
+++ b/Sources/D2Handlers/Message/Handler/MentionD2Handler.swift
@@ -1,9 +1,11 @@
 import Dispatch
 import D2Commands
 import D2MessageIO
+import Logging
 import Utils
 
 fileprivate let mentionPattern = #/<@.+?>/#
+fileprivate let log = Logger(label: "D2Handlers.MentionD2Handler")
 
 public struct MentionD2Handler: MessageHandler {
     private let conversator: Conversator
@@ -13,7 +15,7 @@ public struct MentionD2Handler: MessageHandler {
         self.conversator = conversator
     }
 
-    public func handleRaw(message: Message, sink: any Sink) -> Bool {
+    public func handleRaw(message: Message, sink: any Sink) async -> Bool {
         if let me = sink.me,
             !message.mentionEveryone,
             message.mentions(user: me),
@@ -21,10 +23,23 @@ public struct MentionD2Handler: MessageHandler {
             let guild = message.guild,
             let channelId = message.channelId {
             queue.async {
+                // TODO: Make conversator async
                 if let answer = try? conversator.answer(input: message.content.replacing(mentionPattern, with: ""), on: guild.id) {
-                    sink.sendMessage(Message(content: answer.cleaningMentions(with: guild)), to: channelId)
+                    Task {
+                        do {
+                            try await sink.sendMessage(Message(content: answer.cleaningMentions(with: guild)), to: channelId)
+                        } catch {
+                            log.warning("Could not send reply to D2 mention: \(error)")
+                        }
+                    }
                 } else {
-                    sink.createReaction(for: messageId, on: channelId, emoji: "🤔")
+                    Task {
+                        do {
+                            try await sink.createReaction(for: messageId, on: channelId, emoji: "🤔")
+                        } catch {
+                            log.warning("Could not react to D2 mention: \(error)")
+                        }
+                    }
                 }
             }
             return true

--- a/Sources/D2Handlers/Message/Handler/MentionSomeoneHandler.swift
+++ b/Sources/D2Handlers/Message/Handler/MentionSomeoneHandler.swift
@@ -1,11 +1,18 @@
 import D2MessageIO
+import Logging
+
+private let log = Logger(label: "D2Handlers.MentionSomeoneHandler")
 
 public struct MentionSomeoneHandler: MessageHandler {
     private let rewriter = MentionSomeoneRewriter()
 
-    public func handleRaw(message: Message, sink: any Sink) -> Bool {
+    public func handleRaw(message: Message, sink: any Sink) async -> Bool {
         if let rewrite = rewriter.rewrite(message: message, sink: sink), let channelId = message.channelId {
-            sink.sendMessage(Message(content: rewrite.mentions.map { "<@\($0.id)>" }.joined(separator: " ")), to: channelId)
+            do {
+                try await sink.sendMessage(Message(content: rewrite.mentions.map { "<@\($0.id)>" }.joined(separator: " ")), to: channelId)
+            } catch {
+                log.warning("Could not send @someone response: \(error)")
+            }
             return true
         } else {
             return false

--- a/Sources/D2Handlers/Message/Handler/MessageHandler.swift
+++ b/Sources/D2Handlers/Message/Handler/MessageHandler.swift
@@ -20,7 +20,7 @@ public protocol MessageHandler {
 }
 
 public extension MessageHandler {
-    func handle(message: Message, sink: any Sink) -> Bool { false }
+    func handle(message: Message, sink: any Sink) async -> Bool { false }
 
-    func handleRaw(message: Message, sink: any Sink) -> Bool { false }
+    func handleRaw(message: Message, sink: any Sink) async -> Bool { false }
 }

--- a/Sources/D2Handlers/Message/Handler/ReactionTrigger.swift
+++ b/Sources/D2Handlers/Message/Handler/ReactionTrigger.swift
@@ -2,9 +2,9 @@ import D2MessageIO
 import Utils
 
 public struct ReactionTrigger {
-    let emoji: (Message) -> Promise<String, Error>
+    let emoji: (Message) async throws -> String
 
-    public init(emoji: @escaping (Message) -> Promise<String, Error>) {
+    public init(emoji: @escaping (Message) async throws -> String) {
         self.emoji = emoji
     }
 
@@ -16,17 +16,15 @@ public struct ReactionTrigger {
         emoji: String
     ) {
         self.init { message in
-            Promise.catching {
-                guard Double.random(in: 0..<1) < probability else { throw ReactionTriggerError.notFeelingLucky }
-                guard authorNames.map({ $0.contains(message.author?.username.lowercased() ?? "") }) ?? true else { throw ReactionTriggerError.mismatchingAuthor }
-                guard messageTypes.flatMap({ message.type.map($0.contains) }) ?? true else { throw ReactionTriggerError.mismatchingMessageType }
-                let regex = try! LegacyRegex(
-                    from: "\\b(?:\((keywords ?? []).map(LegacyRegex.escape).joined(separator: "|")))\\b",
-                    caseSensitive: false
-                )
-                guard regex.matchCount(in: message.content) > 0 else { throw ReactionTriggerError.mismatchingKeywords }
-                return emoji
-            }
+            guard Double.random(in: 0..<1) < probability else { throw ReactionTriggerError.notFeelingLucky }
+            guard authorNames.map({ $0.contains(message.author?.username.lowercased() ?? "") }) ?? true else { throw ReactionTriggerError.mismatchingAuthor }
+            guard messageTypes.flatMap({ message.type.map($0.contains) }) ?? true else { throw ReactionTriggerError.mismatchingMessageType }
+            let regex = try! LegacyRegex(
+                from: "\\b(?:\((keywords ?? []).map(LegacyRegex.escape).joined(separator: "|")))\\b",
+                caseSensitive: false
+            )
+            guard regex.matchCount(in: message.content) > 0 else { throw ReactionTriggerError.mismatchingKeywords }
+            return emoji
         }
     }
 }

--- a/Sources/D2Handlers/Message/Handler/SpamHandler.swift
+++ b/Sources/D2Handlers/Message/Handler/SpamHandler.swift
@@ -25,7 +25,7 @@ public struct SpamHandler: MessageHandler {
         lastSpamMessages = ExpiringList(dateProvider: dateProvider)
     }
 
-    public mutating func handle(message: Message, sink: any Sink) -> Bool {
+    public mutating func handle(message: Message, sink: any Sink) async throws -> Bool {
         guard
             isPossiblySpam(message: message),
             let author = message.author,
@@ -37,14 +37,18 @@ public struct SpamHandler: MessageHandler {
         lastSpamMessages.append(message, expiry: (message.timestamp ?? dateProvider()).addingTimeInterval(limits.interval))
 
         if isSpamming(userId: author.id, limits: limits) {
-            if cautionedSpammers.contains(author.id) {
-                sink.sendMessage(Message(content: ":octagonal_sign: Penalizing <@\(author.id)> for spamming!"), to: channelId)
-                penalize(spammer: author.id, on: guild, sink: sink)
-            } else {
-                sink.sendMessage(Message(content: ":warning: Please stop spamming, <@\(author.id)>!"), to: channelId)
-                cautionedSpammers.insert(author.id)
+            do {
+                if cautionedSpammers.contains(author.id) {
+                    try await sink.sendMessage(Message(content: ":octagonal_sign: Penalizing <@\(author.id)> for spamming!"), to: channelId)
+                    try await penalize(spammer: author.id, on: guild, sink: sink)
+                } else {
+                    try await sink.sendMessage(Message(content: ":warning: Please stop spamming, <@\(author.id)>!"), to: channelId)
+                    cautionedSpammers.insert(author.id)
+                }
+                return true
+            } catch {
+                log.warning("Could not send caution message for spamming: \(error)")
             }
-            return true
         }
 
         return false
@@ -58,39 +62,30 @@ public struct SpamHandler: MessageHandler {
         lastSpamMessages.count(forWhich: { ($0.author?.id).map { id in id == userId } ?? false }) > limits.maxSpamMessagesPerInterval
     }
 
-    private func penalize(spammer user: UserID, on guild: Guild, sink: any Sink) {
+    private func penalize(spammer user: UserID, on guild: Guild, sink: any Sink) async throws {
         guard let member = guild.members[user] else { return }
 
         if let role = config.spammerRoles[guild.id] {
-            add(role: role, to: user, on: guild, sink: sink).listenOrLogError {
-                if self.config.removeOtherRolesFromSpammer {
-                    self.remove(roles: member.roleIds, from: user, on: guild, sink: sink)
-                }
+            try await add(role: role, to: user, on: guild, sink: sink)
+            if self.config.removeOtherRolesFromSpammer {
+                try await remove(roles: member.roleIds, from: user, on: guild, sink: sink)
             }
         }
     }
 
-    @discardableResult
-    private func add(role: RoleID, to user: UserID, on guild: Guild, sink: any Sink) -> Promise<Void, any Error> {
-        sink.addGuildMemberRole(role, to: user, on: guild.id, reason: "Spamming").peekListen {
-            if case .success(false) = $0 {
-                log.warning("Could not add role \(role) to spammer \(user)")
-            }
-        }.void()
+    private func add(role: RoleID, to user: UserID, on guild: Guild, sink: any Sink) async throws {
+        guard (try? await sink.addGuildMemberRole(role, to: user, on: guild.id, reason: "Spamming")) ?? false else {
+            log.warning("Could not add role \(role) to spammer \(user)")
+            return
+        }
     }
 
-    @discardableResult
-    private func remove(roles: [RoleID], from user: UserID, on guild: Guild, sink: any Sink) -> Promise<Void, any Error> {
-        var remainingRoles = roles
-        guard let role = remainingRoles.popLast() else {
-            return Promise(.success(()))
-        }
-
-        return sink.removeGuildMemberRole(role, from: user, on: guild.id, reason: "Spamming").then { success in
-            if !success {
+    private func remove(roles: [RoleID], from user: UserID, on guild: Guild, sink: any Sink) async throws {
+        for role in roles {
+            guard (try? await sink.removeGuildMemberRole(role, from: user, on: guild.id, reason: "Spamming")) ?? false else {
                 log.warning("Could not remove role \(role) from spammer \(user)")
+                return
             }
-            return self.remove(roles: remainingRoles, from: user, on: guild, sink: sink)
         }
     }
 }

--- a/Sources/D2Handlers/Message/Handler/TriggerReactionHandler.swift
+++ b/Sources/D2Handlers/Message/Handler/TriggerReactionHandler.swift
@@ -87,11 +87,12 @@ public struct TriggerReactionHandler: MessageHandler {
     public func handle(message: Message, sink: any Sink) async -> Bool {
         if let messageId = message.id, let channelId = message.channelId {
             for trigger in triggers {
-                do {
-                    let emoji = try await trigger.emoji(message)
-                    try await sink.createReaction(for: messageId, on: channelId, emoji: emoji)
-                } catch {
-                    log.warning("Could not create triggered reaction on message \(messageId) in channel \(channelId): \(error)")
+                if let emoji = try? await trigger.emoji(message) {
+                    do {
+                        try await sink.createReaction(for: messageId, on: channelId, emoji: emoji)
+                    } catch {
+                        log.warning("Could not create triggered \(emoji) reaction on message \(messageId) in channel \(channelId): \(error)")
+                    }
                 }
             }
         }

--- a/Sources/D2Handlers/Message/Handler/TriggerReactionHandler.swift
+++ b/Sources/D2Handlers/Message/Handler/TriggerReactionHandler.swift
@@ -3,8 +3,10 @@ import D2Commands
 import D2MessageIO
 import D2NetAPIs
 import Utils
+import Logging
 
 fileprivate let goodMorningOrEveningPattern = #/\bg(?:u+te+n?|oo+d+)\s+(?:mo+(?:rni+ng|(?:rge+|i+)n)|e+ve+ni+ng|a+be+nd|da+y|ta+g|n(?:a+ch|i+gh)t)\b/#.ignoresCase()
+fileprivate let log = Logger(label: "D2Handler.TriggerReactionHandler")
 
 public struct TriggerReactionHandler: MessageHandler {
     private let triggers: [ReactionTrigger]
@@ -21,18 +23,15 @@ public struct TriggerReactionHandler: MessageHandler {
             $configuration: $configuration,
             weatherEmojiProvider: {
                 guard let city = cityConfiguration.city else { throw ReactionTriggerError.other("No city specified") }
-                return OpenWeatherMapQuery(city: city).perform()
-                    .mapCatching {
-                        guard let emoji = $0.emoji else { throw ReactionTriggerError.other("No weather emoji") }
-                        return emoji
-                    }
+                guard let emoji = try await OpenWeatherMapQuery(city: city).perform().get().emoji else { throw ReactionTriggerError.other("No weather emoji") }
+                return emoji
             }
         )
     }
 
     public init(
         @Binding configuration: TriggerReactionConfiguration,
-        weatherEmojiProvider: @escaping () throws -> Promise<String, any Error>
+        weatherEmojiProvider: @escaping () async throws -> String
     ) {
         self.init(triggers: [
             .init(keywords: ["hello"], emoji: "👋"),
@@ -44,56 +43,55 @@ public struct TriggerReactionHandler: MessageHandler {
             .init(messageTypes: [.userPremiumGuildSubscription], emoji: "💎"),
             .init(probability: 0.0001, emoji: "🛸"),
             .init { message in
-                Promise.catchingThen {
-                    guard !message.content.matches(of: goodMorningOrEveningPattern).isEmpty else { throw ReactionTriggerError.mismatchingKeywords }
+                guard !message.content.matches(of: goodMorningOrEveningPattern).isEmpty else { throw ReactionTriggerError.mismatchingKeywords }
 
-                    if configuration.dateSpecificReactions {
-                        let calendar = Calendar.current
-                        let todayComponents = calendar.dateComponents([.month, .day], from: Date())
+                if configuration.dateSpecificReactions {
+                    let calendar = Calendar.current
+                    let todayComponents = calendar.dateComponents([.month, .day], from: Date())
 
-                        // Check for a special day
-                        switch (todayComponents.month, todayComponents.day) {
-                        // Valentine's Day
-                        case (2, 14): return Promise("💘")
-                        // Pi Day
-                        case (3, 14): return Promise("🥧")
-                        // St Patrick's Day
-                        case (3, 17): return Promise("🍀")
-                        // Halloween
-                        case (10, 31): return Promise("🎃")
-                        // Christmas
-                        case (12, 24), (12, 25), (12, 26): return Promise("🎅")
-                        // New Year's Eve
-                        case (12, 31), (1, 1): return Promise("🎆")
-                        default: break
-                        }
-
-                        // Check for guild birthday
-                        if let guild = message.guild, let birthDate = guild.ownerId.flatMap({ guild.members[$0] })?.joinedAt {
-                            let birthDateComponents = calendar.dateComponents([.month, .day], from: birthDate)
-                            if birthDateComponents.month == todayComponents.month && birthDateComponents.day == todayComponents.day {
-                                return Promise("🎂")
-                            }
-                        }
+                    // Check for a special day
+                    switch (todayComponents.month, todayComponents.day) {
+                    // Valentine's Day
+                    case (2, 14): return "💘"
+                    // Pi Day
+                    case (3, 14): return "🥧"
+                    // St Patrick's Day
+                    case (3, 17): return "🍀"
+                    // Halloween
+                    case (10, 31): return "🎃"
+                    // Christmas
+                    case (12, 24), (12, 25), (12, 26): return "🎅"
+                    // New Year's Eve
+                    case (12, 31), (1, 1): return "🎆"
+                    default: break
                     }
 
-                    if configuration.weatherReactions {
-                        return try weatherEmojiProvider()
+                    // Check for guild birthday
+                    if let guild = message.guild, let birthDate = guild.ownerId.flatMap({ guild.members[$0] })?.joinedAt {
+                        let birthDateComponents = calendar.dateComponents([.month, .day], from: birthDate)
+                        if birthDateComponents.month == todayComponents.month && birthDateComponents.day == todayComponents.day {
+                            return "🎂"
+                        }
                     }
-
-                    throw ReactionTriggerError.other("No good morning/evening reaction configured")
                 }
+
+                if configuration.weatherReactions {
+                    return try await weatherEmojiProvider()
+                }
+
+                throw ReactionTriggerError.other("No good morning/evening reaction configured")
             }
         ])
     }
 
-    public func handle(message: Message, sink: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) async -> Bool {
         if let messageId = message.id, let channelId = message.channelId {
             for trigger in triggers {
-                trigger.emoji(message).listen {
-                    if case let .success(emoji) = $0 {
-                        sink.createReaction(for: messageId, on: channelId, emoji: emoji)
-                    }
+                do {
+                    let emoji = try await trigger.emoji(message)
+                    try await sink.createReaction(for: messageId, on: channelId, emoji: emoji)
+                } catch {
+                    log.warning("Could not create triggered reaction on message \(messageId) in channel \(channelId): \(error)")
                 }
             }
         }

--- a/Sources/D2Handlers/Message/Handler/UniversalSummoningHandler.swift
+++ b/Sources/D2Handlers/Message/Handler/UniversalSummoningHandler.swift
@@ -1,8 +1,10 @@
 import D2Commands
 import D2MessageIO
 import Utils
+import Logging
 
 private let theMagicWords = "D2, the chatbots of might, come forth in unison and answer my call."
+private let log = Logger(label: "D2Handlers.UniversalSummoningHandler")
 
 public struct UniversalSummoningHandler: MessageHandler {
     private let hostInfo: HostInfo
@@ -11,11 +13,15 @@ public struct UniversalSummoningHandler: MessageHandler {
         self.hostInfo = hostInfo
     }
 
-    public func handle(message: Message, sink: any Sink) -> Bool {
+    public func handle(message: Message, sink: any Sink) async -> Bool {
         if message.content.trimmingCharacters(in: .whitespacesAndNewlines) == theMagicWords,
            let channelId = message.channelId {
-            sink.sendMessage(Message(content: "Hey, \(hostInfo.instanceName ?? "unknown D2") here"), to: channelId)
-            return true
+            do {
+                try await sink.sendMessage(Message(content: "Hey, \(hostInfo.instanceName ?? "unknown D2") here"), to: channelId)
+                return true
+            } catch {
+                log.warning("Could not respond to being summoned: \(error)")
+            }
         }
         return false
     }

--- a/Sources/D2Handlers/Presence/Handler/PresenceHandler.swift
+++ b/Sources/D2Handlers/Presence/Handler/PresenceHandler.swift
@@ -5,5 +5,5 @@ import D2MessageIO
 public protocol PresenceHandler {
     /// Handles a single presence update. Is invoked
     /// for each presence after connecting.
-    mutating func handle(presenceUpdate presence: Presence, sink: any Sink)
+    mutating func handle(presenceUpdate presence: Presence, sink: any Sink) async
 }

--- a/Sources/D2Handlers/Reaction/Handler/ReactionHandler.swift
+++ b/Sources/D2Handlers/Reaction/Handler/ReactionHandler.swift
@@ -3,11 +3,11 @@ import D2MessageIO
 /// Anything that handles incoming reactions
 /// to messages from Discord.
 public protocol ReactionHandler {
-    mutating func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink)
+    mutating func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) async
 
-    mutating func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink)
+    mutating func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) async
 
-    mutating func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, sink: any Sink)
+    mutating func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, sink: any Sink) async
 }
 
 public extension ReactionHandler {

--- a/Sources/D2Handlers/Reaction/Handler/ReactionHandler.swift
+++ b/Sources/D2Handlers/Reaction/Handler/ReactionHandler.swift
@@ -11,9 +11,9 @@ public protocol ReactionHandler {
 }
 
 public extension ReactionHandler {
-    func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {}
+    func handle(createdReaction emoji: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) async {}
 
-    func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {}
+    func handle(deletedReaction emoji: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) async {}
 
-    func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, sink: any Sink) {}
+    func handle(deletedAllReactionsFrom messageId: MessageID, on channelId: ChannelID, sink: any Sink) async {}
 }

--- a/Sources/D2IRCIO/IRCSink.swift
+++ b/Sources/D2IRCIO/IRCSink.swift
@@ -30,7 +30,7 @@ struct IRCSink: DefaultSink {
             .joined(separator: ", ")
     }
 
-    func sendMessage(_ message: D2MessageIO.Message, to channelId: ChannelID) -> Promise<D2MessageIO.Message?, any Error> {
+    func sendMessage(_ message: D2MessageIO.Message, to channelId: ChannelID) throws -> D2MessageIO.Message? {
         log.debug("Sending message '\(message.content)'")
 
         var text = [message.content, message.embed.map(flatten(embed:))]
@@ -43,11 +43,11 @@ struct IRCSink: DefaultSink {
 
         guard let channelName = IRCChannelName(channelId.value) else {
             log.warning("Could not convert \(channelId.value) (maybe it is missing a leading '#'?)")
-            return Promise(.failure(IRCSinkError.invalidChannelName(channelId.value)))
+            throw IRCSinkError.invalidChannelName(channelId.value)
         }
 
         client.send(.PRIVMSG([.channel(channelName)], text))
 
-        return Promise(.success(message))
+        return message
     }
 }

--- a/Sources/D2MessageIO/DefaultSink.swift
+++ b/Sources/D2MessageIO/DefaultSink.swift
@@ -42,133 +42,133 @@ public extension DefaultSink {
         nil
     }
 
-    func addGuildMemberRole(_ roleId: RoleID, to userId: UserID, on guildId: GuildID, reason: String?) -> Promise<Bool, any Error> {
+    func addGuildMemberRole(_ roleId: RoleID, to userId: UserID, on guildId: GuildID, reason: String?) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func removeGuildMemberRole(_ roleId: RoleID, from userId: UserID, on guildId: GuildID, reason: String?) -> Promise<Bool, any Error> {
+    func removeGuildMemberRole(_ roleId: RoleID, from userId: UserID, on guildId: GuildID, reason: String?) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func createDM(with userId: UserID) -> Promise<ChannelID?, any Error> {
+    func createDM(with userId: UserID) async throws -> ChannelID? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func sendMessage(_ message: D2MessageIO.Message, to channelId: ChannelID) -> Promise<D2MessageIO.Message?, any Error> {
+    func sendMessage(_ message: D2MessageIO.Message, to channelId: ChannelID) async throws -> D2MessageIO.Message? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func editMessage(_ id: MessageID, on channelId: ChannelID, content: String) -> Promise<D2MessageIO.Message?, any Error> {
+    func editMessage(_ id: MessageID, on channelId: ChannelID, content: String) async throws -> D2MessageIO.Message? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func deleteMessage(_ id: MessageID, on channelId: ChannelID) -> Promise<Bool, any Error> {
+    func deleteMessage(_ id: MessageID, on channelId: ChannelID) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func bulkDeleteMessages(_ ids: [MessageID], on channelId: ChannelID) -> Promise<Bool, any Error> {
+    func bulkDeleteMessages(_ ids: [MessageID], on channelId: ChannelID) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func getMessages(for channelId: ChannelID, limit: Int, selection: MessageSelection?) -> Promise<[D2MessageIO.Message], any Error> {
+    func getMessages(for channelId: ChannelID, limit: Int, selection: MessageSelection?) async throws -> [D2MessageIO.Message] {
         // TODO
-        Promise(.success([]))
+        []
     }
 
-    func modifyChannel(_ channelId: ChannelID, with modification: ChannelModification) -> Promise<D2MessageIO.Channel?, any Error> {
+    func modifyChannel(_ channelId: ChannelID, with modification: ChannelModification) async throws -> D2MessageIO.Channel? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func isGuildTextChannel(_ channelId: ChannelID) -> Promise<Bool, any Error> {
+    func isGuildTextChannel(_ channelId: ChannelID) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func isDMTextChannel(_ channelId: ChannelID) -> Promise<Bool, any Error> {
+    func isDMTextChannel(_ channelId: ChannelID) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func triggerTyping(on channelId: ChannelID) -> Promise<Bool, any Error> {
+    func triggerTyping(on channelId: ChannelID) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func createReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Promise<D2MessageIO.Message?, any Error> {
+    func createReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) async throws -> D2MessageIO.Message? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func deleteOwnReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Promise<Bool, any Error> {
+    func deleteOwnReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func deleteUserReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String, by userId: UserID) -> Promise<Bool, any Error> {
+    func deleteUserReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String, by userId: UserID) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func createEmoji(on guildId: GuildID, name: String, image: String, roles: [RoleID]) -> Promise<D2MessageIO.Emoji?, any Error> {
+    func createEmoji(on guildId: GuildID, name: String, image: String, roles: [RoleID]) async throws -> D2MessageIO.Emoji? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func deleteEmoji(from guildId: GuildID, emojiId: EmojiID) -> Promise<Bool, any Error> {
+    func deleteEmoji(from guildId: GuildID, emojiId: EmojiID) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func getMIOCommands() -> Promise<[MIOCommand], any Error> {
+    func getMIOCommands() async throws -> [MIOCommand] {
         // TODO
-        Promise(.success([]))
+        []
     }
 
-    func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
+    func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
+    func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func deleteMIOCommand(_ commandId: MIOCommandID) -> Promise<Bool, any Error> {
+    func deleteMIOCommand(_ commandId: MIOCommandID) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func getMIOCommands(on guildId: GuildID) -> Promise<[MIOCommand], any Error> {
+    func getMIOCommands(on guildId: GuildID) async throws -> [MIOCommand] {
         // TODO
-        Promise(.success([]))
+        []
     }
 
-    func createMIOCommand(on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
+    func createMIOCommand(on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
+    func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
         // TODO
-        Promise(.success(nil))
+        nil
     }
 
-    func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) -> Promise<Bool, any Error> {
+    func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 
-    func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, any Error> {
+    func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) async throws -> Bool {
         // TODO
-        Promise(.success(false))
+        false
     }
 }

--- a/Sources/D2MessageIO/OverlaySink.swift
+++ b/Sources/D2MessageIO/OverlaySink.swift
@@ -24,8 +24,8 @@ public struct OverlaySink: Sink {
         inner.channel(for: channelId)
     }
 
-    public func setPresence(_ presence: PresenceUpdate) {
-        inner.setPresence(presence)
+    public func setPresence(_ presence: PresenceUpdate) async throws {
+        try await inner.setPresence(presence)
     }
 
     public func guildForChannel(_ channelId: ChannelID) -> Guild? {
@@ -40,107 +40,107 @@ public struct OverlaySink: Sink {
         inner.avatarUrlForUser(userId, with: avatarId, size: size, preferredExtension: preferredExtension)
     }
 
-    public func addGuildMemberRole(_ roleId: RoleID, to userId: UserID, on guildId: GuildID, reason: String?) -> Promise<Bool, any Error> {
-        inner.addGuildMemberRole(roleId, to: userId, on: guildId, reason: reason)
+    public func addGuildMemberRole(_ roleId: RoleID, to userId: UserID, on guildId: GuildID, reason: String?) async throws -> Bool {
+        try await inner.addGuildMemberRole(roleId, to: userId, on: guildId, reason: reason)
     }
 
-    public func removeGuildMemberRole(_ roleId: RoleID, from userId: UserID, on guildId: GuildID, reason: String?) -> Promise<Bool, any Error> {
-        inner.removeGuildMemberRole(roleId, from: userId, on: guildId, reason: reason)
+    public func removeGuildMemberRole(_ roleId: RoleID, from userId: UserID, on guildId: GuildID, reason: String?) async throws -> Bool {
+        try await inner.removeGuildMemberRole(roleId, from: userId, on: guildId, reason: reason)
     }
 
-    public func createDM(with userId: UserID) -> Promise<ChannelID?, any Error> {
-        inner.createDM(with: userId)
+    public func createDM(with userId: UserID) async throws -> ChannelID? {
+        try await inner.createDM(with: userId)
     }
 
-    public func sendMessage(_ message: Message, to channelId: ChannelID) -> Promise<Message?, any Error> {
-        inner.sendMessage(message, to: channelId)
+    public func sendMessage(_ message: Message, to channelId: ChannelID) async throws -> Message? {
+        try await inner.sendMessage(message, to: channelId)
     }
 
-    public func editMessage(_ id: MessageID, on channelId: ChannelID, content: String) -> Promise<Message?, any Error> {
-        inner.editMessage(id, on: channelId, content: content)
+    public func editMessage(_ id: MessageID, on channelId: ChannelID, content: String) async throws -> Message? {
+        try await inner.editMessage(id, on: channelId, content: content)
     }
 
-    public func deleteMessage(_ id: MessageID, on channelId: ChannelID) -> Promise<Bool, any Error> {
-        inner.deleteMessage(id, on: channelId)
+    public func deleteMessage(_ id: MessageID, on channelId: ChannelID) async throws -> Bool {
+        try await inner.deleteMessage(id, on: channelId)
     }
 
-    public func bulkDeleteMessages(_ ids: [MessageID], on channelId: ChannelID) -> Promise<Bool, any Error> {
-        inner.bulkDeleteMessages(ids, on: channelId)
+    public func bulkDeleteMessages(_ ids: [MessageID], on channelId: ChannelID) async throws -> Bool {
+        try await inner.bulkDeleteMessages(ids, on: channelId)
     }
 
-    public func getMessages(for channelId: ChannelID, limit: Int, selection: MessageSelection?) -> Promise<[Message], any Error> {
-        inner.getMessages(for: channelId, limit: limit, selection: selection)
+    public func getMessages(for channelId: ChannelID, limit: Int, selection: MessageSelection?) async throws -> [Message] {
+        try await inner.getMessages(for: channelId, limit: limit, selection: selection)
     }
 
-    public func modifyChannel(_ channelId: ChannelID, with modification: ChannelModification) -> Promise<Channel?, any Error> {
-        inner.modifyChannel(channelId, with: modification)
+    public func modifyChannel(_ channelId: ChannelID, with modification: ChannelModification) async throws -> Channel? {
+        try await inner.modifyChannel(channelId, with: modification)
     }
 
-    public func isGuildTextChannel(_ channelId: ChannelID) -> Promise<Bool, any Error> {
-        inner.isGuildTextChannel(channelId)
+    public func isGuildTextChannel(_ channelId: ChannelID) async throws -> Bool {
+        try await inner.isGuildTextChannel(channelId)
     }
 
-    public func isDMTextChannel(_ channelId: ChannelID) -> Promise<Bool, any Error> {
-        inner.isDMTextChannel(channelId)
+    public func isDMTextChannel(_ channelId: ChannelID) async throws -> Bool {
+        try await inner.isDMTextChannel(channelId)
     }
 
-    public func triggerTyping(on channelId: ChannelID) -> Promise<Bool, any Error> {
-        inner.triggerTyping(on: channelId)
+    public func triggerTyping(on channelId: ChannelID) async throws -> Bool {
+        try await inner.triggerTyping(on: channelId)
     }
 
-    public func createReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Promise<Message?, any Error> {
-        inner.createReaction(for: messageId, on: channelId, emoji: emoji)
+    public func createReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) async throws -> Message? {
+        try await inner.createReaction(for: messageId, on: channelId, emoji: emoji)
     }
 
-    public func deleteOwnReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Promise<Bool, any Error> {
-        inner.deleteOwnReaction(for: messageId, on: channelId, emoji: emoji)
+    public func deleteOwnReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) async throws -> Bool {
+        try await inner.deleteOwnReaction(for: messageId, on: channelId, emoji: emoji)
     }
 
-    public func deleteUserReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String, by userId: UserID) -> Promise<Bool, any Error> {
-        inner.deleteUserReaction(for: messageId, on: channelId, emoji: emoji, by: userId)
+    public func deleteUserReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String, by userId: UserID) async throws -> Bool {
+        try await inner.deleteUserReaction(for: messageId, on: channelId, emoji: emoji, by: userId)
     }
 
-    public func createEmoji(on guildId: GuildID, name: String, image: String, roles: [RoleID]) -> Promise<Emoji?, any Error> {
-        inner.createEmoji(on: guildId, name: name, image: image, roles: roles)
+    public func createEmoji(on guildId: GuildID, name: String, image: String, roles: [RoleID]) async throws -> Emoji? {
+        try await inner.createEmoji(on: guildId, name: name, image: image, roles: roles)
     }
 
-    public func deleteEmoji(from guildId: GuildID, emojiId: EmojiID) -> Promise<Bool, any Error> {
-        inner.deleteEmoji(from: guildId, emojiId: emojiId)
+    public func deleteEmoji(from guildId: GuildID, emojiId: EmojiID) async throws -> Bool {
+        try await inner.deleteEmoji(from: guildId, emojiId: emojiId)
     }
 
-    public func getMIOCommands() -> Promise<[MIOCommand], any Error> {
-        inner.getMIOCommands()
+    public func getMIOCommands() async throws -> [MIOCommand] {
+        try await inner.getMIOCommands()
     }
 
-    public func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        inner.createMIOCommand(name: name, description: description, options: options)
+    public func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
+        try await inner.createMIOCommand(name: name, description: description, options: options)
     }
 
-    public func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        inner.editMIOCommand(commandId, name: name, description: description, options: options)
+    public func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
+        try await inner.editMIOCommand(commandId, name: name, description: description, options: options)
     }
 
-    public func deleteMIOCommand(_ commandId: MIOCommandID) -> Promise<Bool, any Error> {
-        inner.deleteMIOCommand(commandId)
+    public func deleteMIOCommand(_ commandId: MIOCommandID) async throws -> Bool {
+        try await inner.deleteMIOCommand(commandId)
     }
 
-    public func getMIOCommands(on guildId: GuildID) -> Promise<[MIOCommand], any Error> {
-        inner.getMIOCommands(on: guildId)
+    public func getMIOCommands(on guildId: GuildID) async throws -> [MIOCommand] {
+        try await inner.getMIOCommands(on: guildId)
     }
 
-    public func createMIOCommand(on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        inner.createMIOCommand(on: guildId, name: name, description: description, options: options)
+    public func createMIOCommand(on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
+        try await inner.createMIOCommand(on: guildId, name: name, description: description, options: options)
     }
 
-    public func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error> {
-        inner.editMIOCommand(commandId, on: guildId, name: name, description: description, options: options)
+    public func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand? {
+        try await inner.editMIOCommand(commandId, on: guildId, name: name, description: description, options: options)
     }
 
-    public func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) -> Promise<Bool, any Error> {
-        inner.deleteMIOCommand(commandId, on: guildId)
+    public func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) async throws -> Bool {
+        try await inner.deleteMIOCommand(commandId, on: guildId)
     }
 
-    public func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, any Error> {
-        inner.createInteractionResponse(for: interactionId, token: token, response: response)
+    public func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) async throws -> Bool {
+        try await inner.createInteractionResponse(for: interactionId, token: token, response: response)
     }
 }

--- a/Sources/D2MessageIO/Sink.swift
+++ b/Sources/D2MessageIO/Sink.swift
@@ -15,7 +15,7 @@ public protocol Sink {
 
     func channel(for channelId: ChannelID) -> Channel?
 
-    func setPresence(_ presence: PresenceUpdate)
+    func setPresence(_ presence: PresenceUpdate) async throws
 
     func guildForChannel(_ channelId: ChannelID) -> Guild?
 
@@ -24,95 +24,95 @@ public protocol Sink {
     func avatarUrlForUser(_ userId: UserID, with avatarId: String, size: Int, preferredExtension: String?) -> URL?
 
     @discardableResult
-    func addGuildMemberRole(_ roleId: RoleID, to userId: UserID, on guildId: GuildID, reason: String?) -> Promise<Bool, any Error>
+    func addGuildMemberRole(_ roleId: RoleID, to userId: UserID, on guildId: GuildID, reason: String?) async throws -> Bool
 
     @discardableResult
-    func removeGuildMemberRole(_ roleId: RoleID, from userId: UserID, on guildId: GuildID, reason: String?) -> Promise<Bool, any Error>
+    func removeGuildMemberRole(_ roleId: RoleID, from userId: UserID, on guildId: GuildID, reason: String?) async throws -> Bool
 
     @discardableResult
-    func createDM(with userId: UserID) -> Promise<ChannelID?, any Error>
+    func createDM(with userId: UserID) async throws -> ChannelID?
 
     @discardableResult
-    func sendMessage(_ message: Message, to channelId: ChannelID) -> Promise<Message?, any Error>
+    func sendMessage(_ message: Message, to channelId: ChannelID) async throws -> Message?
 
     @discardableResult
-    func editMessage(_ id: MessageID, on channelId: ChannelID, content: String) -> Promise<Message?, any Error>
+    func editMessage(_ id: MessageID, on channelId: ChannelID, content: String) async throws -> Message?
 
     @discardableResult
-    func deleteMessage(_ id: MessageID, on channelId: ChannelID) -> Promise<Bool, any Error>
+    func deleteMessage(_ id: MessageID, on channelId: ChannelID) async throws -> Bool
 
     @discardableResult
-    func bulkDeleteMessages(_ ids: [MessageID], on channelId: ChannelID) -> Promise<Bool, any Error>
+    func bulkDeleteMessages(_ ids: [MessageID], on channelId: ChannelID) async throws -> Bool
 
     @discardableResult
-    func getMessages(for channelId: ChannelID, limit: Int, selection: MessageSelection?) -> Promise<[Message], any Error>
+    func getMessages(for channelId: ChannelID, limit: Int, selection: MessageSelection?) async throws -> [Message]
 
     @discardableResult
-    func modifyChannel(_ channelId: ChannelID, with modification: ChannelModification) -> Promise<Channel?, any Error>
+    func modifyChannel(_ channelId: ChannelID, with modification: ChannelModification) async throws -> Channel?
 
     @discardableResult
-    func isGuildTextChannel(_ channelId: ChannelID) -> Promise<Bool, any Error>
+    func isGuildTextChannel(_ channelId: ChannelID) async throws -> Bool
 
     @discardableResult
-    func isDMTextChannel(_ channelId: ChannelID) -> Promise<Bool, any Error>
+    func isDMTextChannel(_ channelId: ChannelID) async throws -> Bool
 
     @discardableResult
-    func triggerTyping(on channelId: ChannelID) -> Promise<Bool, any Error>
+    func triggerTyping(on channelId: ChannelID) async throws -> Bool
 
     @discardableResult
-    func createReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Promise<Message?, any Error>
+    func createReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) async throws -> Message?
 
     @discardableResult
-    func deleteOwnReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Promise<Bool, any Error>
+    func deleteOwnReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) async throws -> Bool
 
     @discardableResult
-    func deleteUserReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String, by userId: UserID) -> Promise<Bool, any Error>
+    func deleteUserReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String, by userId: UserID) async throws -> Bool
 
     @discardableResult
-    func createEmoji(on guildId: GuildID, name: String, image: String, roles: [RoleID]) -> Promise<Emoji?, any Error>
+    func createEmoji(on guildId: GuildID, name: String, image: String, roles: [RoleID]) async throws -> Emoji?
 
     @discardableResult
-    func deleteEmoji(from guildId: GuildID, emojiId: EmojiID) -> Promise<Bool, any Error>
+    func deleteEmoji(from guildId: GuildID, emojiId: EmojiID) async throws -> Bool
 
     @discardableResult
-    func getMIOCommands() -> Promise<[MIOCommand], any Error>
+    func getMIOCommands() async throws -> [MIOCommand]
 
     @discardableResult
-    func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error>
+    func createMIOCommand(name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand?
 
     @discardableResult
-    func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error>
+    func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand?
 
     @discardableResult
-    func deleteMIOCommand(_ commandId: MIOCommandID) -> Promise<Bool, any Error>
+    func deleteMIOCommand(_ commandId: MIOCommandID) async throws -> Bool
 
     @discardableResult
-    func getMIOCommands(on guildId: GuildID) -> Promise<[MIOCommand], any Error>
+    func getMIOCommands(on guildId: GuildID) async throws -> [MIOCommand]
 
     @discardableResult
-    func createMIOCommand(on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error>
+    func createMIOCommand(on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand?
 
     @discardableResult
-    func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) -> Promise<MIOCommand?, any Error>
+    func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String, options: [MIOCommand.Option]?) async throws -> MIOCommand?
 
     @discardableResult
-    func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) -> Promise<Bool, any Error>
+    func deleteMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID) async throws -> Bool
 
     @discardableResult
-    func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) -> Promise<Bool, any Error>
+    func createInteractionResponse(for interactionId: InteractionID, token: String, response: InteractionResponse) async throws -> Bool
 }
 
 public extension Sink {
-    func sendMessage(_ content: String, to channelId: ChannelID) {
-        sendMessage(Message(content: content), to: channelId)
+    func sendMessage(_ content: String, to channelId: ChannelID) async throws {
+        try await sendMessage(Message(content: content), to: channelId)
     }
 
-    func getMessages(for channelId: ChannelID, limit: Int) -> Promise<[Message], any Error> {
-        getMessages(for: channelId, limit: limit, selection: nil)
+    func getMessages(for channelId: ChannelID, limit: Int) async throws -> [Message] {
+        try await getMessages(for: channelId, limit: limit, selection: nil)
     }
 
-    func createEmoji(on guildId: GuildID, name: String, image: String) -> Promise<Emoji?, any Error> {
-        createEmoji(on: guildId, name: name, image: image, roles: [])
+    func createEmoji(on guildId: GuildID, name: String, image: String) async throws -> Emoji? {
+        try await createEmoji(on: guildId, name: name, image: image, roles: [])
     }
 
     func avatarUrlForUser(_ userId: UserID, with avatarId: String, size: Int) -> URL? {
@@ -124,43 +124,37 @@ public extension Sink {
     }
 
     @discardableResult
-    func createMIOCommand(name: String, description: String) -> Promise<MIOCommand?, any Error> {
-        createMIOCommand(name: name, description: description, options: nil)
+    func createMIOCommand(name: String, description: String) async throws -> MIOCommand? {
+        try await createMIOCommand(name: name, description: description, options: nil)
     }
 
     @discardableResult
-    func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String) -> Promise<MIOCommand?, any Error> {
-        editMIOCommand(commandId, name: name, description: description, options: nil)
+    func editMIOCommand(_ commandId: MIOCommandID, name: String, description: String) async throws -> MIOCommand? {
+        try await editMIOCommand(commandId, name: name, description: description, options: nil)
     }
 
     @discardableResult
-    func createMIOCommand(on guildId: GuildID, name: String, description: String) -> Promise<MIOCommand?, any Error> {
-        createMIOCommand(on: guildId, name: name, description: description, options: nil)
+    func createMIOCommand(on guildId: GuildID, name: String, description: String) async throws -> MIOCommand? {
+        try await createMIOCommand(on: guildId, name: name, description: description, options: nil)
     }
 
     @discardableResult
-    func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String) -> Promise<MIOCommand?, any Error> {
-        editMIOCommand(commandId, on: guildId, name: name, description: description, options: nil)
+    func editMIOCommand(_ commandId: MIOCommandID, on guildId: GuildID, name: String, description: String) async throws -> MIOCommand? {
+        try await editMIOCommand(commandId, on: guildId, name: name, description: description, options: nil)
     }
 
-    @discardableResult
-    func deleteMIOCommands() -> Promise<Void, any Error> {
+    func deleteMIOCommands() async throws {
         // Note how this only deletes *global* MIO commands
-        getMIOCommands().then {
-            all(promises: $0.map { cmd -> Promise<Bool, any Error> in
-                log.info("Deleting MIO command with ID \(cmd.id)")
-                return deleteMIOCommand(cmd.id)
-            }).void()
+        for command in try await getMIOCommands() {
+            log.info("Deleting MIO command with ID \(command.id)")
+            try await deleteMIOCommand(command.id)
         }
     }
 
-    @discardableResult
-    func deleteMIOCommands(on guildId: GuildID) -> Promise<Void, any Error> {
-        getMIOCommands(on: guildId).then {
-            all(promises: $0.map { cmd -> Promise<Bool, any Error> in
-                log.info("Deleting MIO command with ID \(cmd.id) from guild \(guildId)")
-                return deleteMIOCommand(cmd.id, on: guildId)
-            }).void()
+    func deleteMIOCommands(on guildId: GuildID) async throws {
+        for command in try await getMIOCommands(on: guildId) {
+            log.info("Deleting MIO command with ID \(command.id) from guild \(guildId)")
+            try await deleteMIOCommand(command.id, on: guildId)
         }
     }
 }

--- a/Sources/D2MessageIO/Utils/MessageIOImageUtils.swift
+++ b/Sources/D2MessageIO/Utils/MessageIOImageUtils.swift
@@ -3,12 +3,12 @@ import CairoGraphics
 import GIF
 
 extension InteractiveTextChannel {
-    public func send(image: CairoImage) throws {
-        send(try Message(fromImage: image))
+    public func send(image: CairoImage) async throws {
+        try await send(Message(fromImage: image))
     }
 
-    public func send(gif: GIF) throws {
-        send(try Message(fromGif: gif))
+    public func send(gif: GIF) async throws {
+        try await send(Message(fromGif: gif))
     }
 }
 

--- a/Sources/D2MessageIO/Utils/MessageIOUtils.swift
+++ b/Sources/D2MessageIO/Utils/MessageIOUtils.swift
@@ -2,12 +2,12 @@ import Utils
 import Foundation
 
 extension InteractiveTextChannel {
-    public func send(_ message: String) {
-        send(Message(content: message))
+    public func send(_ message: String) async throws {
+        try await send(Message(content: message))
     }
 
-    public func send(embed: Embed) {
-        send(Message(embed: embed))
+    public func send(embed: Embed) async throws {
+        try await send(Message(embed: embed))
     }
 }
 

--- a/Sources/D2MessageIO/Wrappers/InteractiveTextChannel.swift
+++ b/Sources/D2MessageIO/Wrappers/InteractiveTextChannel.swift
@@ -12,12 +12,12 @@ public struct InteractiveTextChannel {
     }
 
     @discardableResult
-    public func send(_ message: Message) -> Promise<Message?, any Error> {
-        sink.sendMessage(message, to: id)
+    public func send(_ message: Message) async throws -> Message? {
+        try await sink.sendMessage(message, to: id)
     }
 
     @discardableResult
-    public func triggerTyping() -> Promise<Bool, any Error> {
-        sink.triggerTyping(on: id)
+    public func triggerTyping() async throws -> Bool {
+        try await sink.triggerTyping(on: id)
     }
 }

--- a/Sources/D2MessageIO/Wrappers/TypingIndicator.swift
+++ b/Sources/D2MessageIO/Wrappers/TypingIndicator.swift
@@ -20,7 +20,9 @@ public class TypingIndicator {
 
     private func repeatedlyTriggerTypingInBackground() {
         guard running else { return }
-        channel.triggerTyping()
+        Task {
+            _ = try? await channel.triggerTyping()
+        }
 
         let timeout = DispatchTime.now() + .seconds(9)
         queue.asyncAfter(deadline: timeout) {

--- a/Tests/D2CommandTests/Game/TicTacToe/TicTacToeCommandTests.swift
+++ b/Tests/D2CommandTests/Game/TicTacToe/TicTacToeCommandTests.swift
@@ -14,8 +14,6 @@ final class TicTacToeCommandTests: XCTestCase {
     private let playerO = GamePlayer(username: nameO)
 
     func testXWin() async throws {
-        return // FIXME: Re-enable this test once Sink etc. are async, otherwise the awaits might not actually await
-
         let command = GameCommand<TicTacToeGame>()
         let output = TestOutput()
         let channel = dummyId
@@ -48,8 +46,6 @@ final class TicTacToeCommandTests: XCTestCase {
     }
 
     func testDraw() async throws {
-        return // FIXME: Re-enable this test once Sink etc. are async, otherwise the awaits might not actually await
-
         let command = GameCommand<TicTacToeGame>()
         let output = TestOutput()
         let channel = dummyId

--- a/Tests/D2CommandTests/Misc/EchoCommandTests.swift
+++ b/Tests/D2CommandTests/Misc/EchoCommandTests.swift
@@ -4,8 +4,6 @@ import D2TestUtils
 
 final class EchoCommandTests: XCTestCase {
     func testInvocation() async throws {
-        return // FIXME: Re-enable this test once Sink etc. are async, otherwise the awaits might not actually await
-
         let command = EchoCommand()
         let output = TestOutput()
 

--- a/Tests/D2CommandTests/Music/FindKeyCommandTests.swift
+++ b/Tests/D2CommandTests/Music/FindKeyCommandTests.swift
@@ -5,8 +5,6 @@ import D2TestUtils
 
 final class FindKeyCommandTests: XCTestCase {
     func testFindKey() async throws {
-        return // FIXME: Re-enable this test once Sink etc. are async, otherwise the awaits might not actually await
-
         let command = FindKeyCommand()
         let output = TestOutput()
 

--- a/Tests/D2HandlersTests/Message/Handler/LuckyNumberHandlerTests.swift
+++ b/Tests/D2HandlersTests/Message/Handler/LuckyNumberHandlerTests.swift
@@ -22,7 +22,7 @@ final class LuckyNumberHandlerTests: XCTestCase {
         XCTAssertTrue(handler.isLucky(420))
     }
 
-    func testMessageTrigger() {
+    func testMessageTrigger() async {
         let handler = LuckyNumberHandler(luckyNumbers: [42])
         let output = TestOutput()
 
@@ -31,7 +31,7 @@ final class LuckyNumberHandlerTests: XCTestCase {
             channelId: ID("Dummy Channel")
         )
         output.messages.append(message)
-        _ = handler.handle(message: message, sink: output)
+        _ = await handler.handle(message: message, sink: output)
 
         XCTAssertEqual(output.lastContent, """
             All the numbers in your message added up to 42. Congrats!

--- a/Tests/D2HandlersTests/Message/Handler/SpamHandlerTests.swift
+++ b/Tests/D2HandlersTests/Message/Handler/SpamHandlerTests.swift
@@ -23,57 +23,57 @@ final class SpamHandlerTests: XCTestCase {
         channelId = ChannelID("0")
     }
 
-    func testNewUserSpamming() {
+    func testNewUserSpamming() async throws {
         join(daysAgo: 0.2)
 
         XCTAssert(!isWarned())
         XCTAssert(!isPenalized())
 
-        spam(after: 0.5)
+        try await spam(after: 0.5)
 
         XCTAssert(isWarned())
         XCTAssert(!isPenalized())
 
-        spam(after: 0.5)
+        try await spam(after: 0.5)
 
         XCTAssert(isWarned())
         XCTAssert(isPenalized())
     }
 
-    func testOlderUserSpamming() {
+    func testOlderUserSpamming() async throws {
         join(daysAgo: 32)
 
-        spam() // This one should be expired by the time the second one is sent
-        spam(after: 200)
-        spam()
-        spam()
-        spam()
+        try await spam() // This one should be expired by the time the second one is sent
+        try await spam(after: 200)
+        try await spam()
+        try await spam()
+        try await spam()
 
         XCTAssert(!isWarned())
         XCTAssert(!isPenalized())
 
-        spam()
+        try await spam()
 
         XCTAssert(isWarned())
         XCTAssert(!isPenalized())
     }
 
-    func testEvenOlderUserSpamming() {
+    func testEvenOlderUserSpamming() async throws {
         join(daysAgo: 365)
 
         for _ in 0..<6 {
-            spam()
+            try await spam()
         }
 
         XCTAssert(!isWarned())
         XCTAssert(!isPenalized())
 
-        spam()
+        try await spam()
 
         XCTAssert(isWarned())
         XCTAssert(!isPenalized())
 
-        spam()
+        try await spam()
 
         XCTAssert(isWarned())
         XCTAssert(isPenalized())
@@ -87,9 +87,9 @@ final class SpamHandlerTests: XCTestCase {
         output.guilds!.append(guild)
     }
 
-    private func spam(after interval: TimeInterval = 0) {
+    private func spam(after interval: TimeInterval = 0) async throws {
         timestamp += interval
-        let _ = handler.handle(message: Message(content: "@everyone", author: user, channelId: channelId, mentionEveryone: true, timestamp: timestamp), sink: output)
+        let _ = try await handler.handle(message: Message(content: "@everyone", author: user, channelId: channelId, mentionEveryone: true, timestamp: timestamp), sink: output)
     }
 
     private func isWarned() -> Bool {

--- a/Tests/D2HandlersTests/Message/Handler/TriggerReactionHandlerTests.swift
+++ b/Tests/D2HandlersTests/Message/Handler/TriggerReactionHandlerTests.swift
@@ -5,17 +5,21 @@ import D2TestUtils
 @testable import D2Handlers
 
 final class TriggerReactionHandlers: XCTestCase {
-    func testGoodMorningReaction() {
-        XCTAssertFalse(messageTriggersWeather("good mornin"))
-        XCTAssertFalse(messageTriggersWeather("Moin"))
-        XCTAssert(messageTriggersWeather("good morning"))
-        XCTAssert(messageTriggersWeather("guten moin"))
-        XCTAssert(messageTriggersWeather("Guten Morgen"))
-        XCTAssert(messageTriggersWeather("Guten   mooorgen"))
-        XCTAssert(messageTriggersWeather("Guten Morgen, guten Morgen, guten Morgen, Sonnenschein!"))
+    func testGoodMorningReaction() async {
+        assert(!(await messageTriggersWeather("good mornin")))
+        assert(!(await messageTriggersWeather("Moin")))
+        assert(await messageTriggersWeather("good morning"))
+        assert(await messageTriggersWeather("guten moin"))
+        assert(await messageTriggersWeather("Guten Morgen"))
+        assert(await messageTriggersWeather("Guten   mooorgen"))
+        assert(await messageTriggersWeather("Guten Morgen, guten Morgen, guten Morgen, Sonnenschein!"))
     }
 
-    private func messageTriggersWeather(_ content: String) -> Bool {
+    private func assert(_ condition: Bool, line: UInt = #line) {
+        XCTAssert(condition, line: line)
+    }
+
+    private func messageTriggersWeather(_ content: String) async -> Bool {
         let emoji = ":test:"
         let handler = TriggerReactionHandler($configuration: .constant(
             TriggerReactionConfiguration(
@@ -23,7 +27,7 @@ final class TriggerReactionHandlers: XCTestCase {
                 weatherReactions: true
             )
         )) {
-            Promise(emoji)
+            emoji
         }
         let output = TestOutput()
         let message = Message(
@@ -32,7 +36,7 @@ final class TriggerReactionHandlers: XCTestCase {
             id: ID("Dummy Message")
         )
         output.messages.append(message)
-        _ = handler.handle(message: message, sink: output)
+        _ = await handler.handle(message: message, sink: output)
         return output.lastReactions.contains { $0.emoji.name == emoji }
     }
 }

--- a/Tests/D2TestUtils/TestOutput.swift
+++ b/Tests/D2TestUtils/TestOutput.swift
@@ -70,12 +70,12 @@ extension TestOutput: DefaultSink {
         guilds?.first { $0.channels.keys.contains(channelId) }
     }
 
-    public func sendMessage(_ message: D2MessageIO.Message, to channelId: ChannelID) -> Promise<D2MessageIO.Message?, any Error> {
+    public func sendMessage(_ message: D2MessageIO.Message, to channelId: ChannelID) -> D2MessageIO.Message? {
         append(message: message)
-        return Promise(.success(message))
+        return message
     }
 
-    public func createReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Promise<Message?, Error> {
+    public func createReaction(for messageId: MessageID, on channelId: ChannelID, emoji: String) -> Message? {
         for i in messages.indices where messages[i].id == messageId {
             var reactions = Dictionary(grouping: messages[i].reactions, by: \.emoji.description)
             // TODO: Add proper conversion from emoji string to Emoji structure
@@ -90,6 +90,6 @@ extension TestOutput: DefaultSink {
             messages[i].reactions = reactions.values.flatMap { $0 }
             return .init(messages[i])
         }
-        return .init(nil)
+        return nil
     }
 }


### PR DESCRIPTION
This is a rather large change, since we would otherwise need synchronous (`Task`-spawning) wrappers around the `Sink` methods, like in `CommandOutput`.