### PR TITLE
Migrate `Receiver` and `D2Receiver` to async

### DIFF
--- a/Sources/D2DiscordIO/DiscordClientManager.swift
+++ b/Sources/D2DiscordIO/DiscordClientManager.swift
@@ -38,57 +38,79 @@ public class DiscordClientManager: DiscordClientDelegate {
 
     public func client(_ discordClient: DiscordClient, didConnect connected: Bool) {
         log.info("Connected")
-        receiver.on(connect: connected, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(connect: connected, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ client: DiscordClient, didDisconnectWithReason reason: DiscordGatewayCloseReason, closed: Bool) {
         log.info("Got disconnect with reason \(reason)")
-        receiver.on(disconnectWithReason: String(describing: reason), sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(disconnectWithReason: String(describing: reason), sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didCreateChannel channel: DiscordChannel) {
         log.debug("Got channel create: \(channel.id)")
-        receiver.on(createChannel: channel.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(createChannel: channel.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didDeleteChannel channel: DiscordChannel) {
         log.debug("Got channel delete: \(channel.id)")
-        receiver.on(deleteChannel: channel.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(deleteChannel: channel.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didUpdateChannel channel: DiscordChannel) {
         log.debug("Got channel update: \(channel.id)")
-        receiver.on(updateChannel: channel.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(updateChannel: channel.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didCreateThread thread: DiscordChannel) {
         log.debug("Got thread create: \(thread.id)")
-        receiver.on(createThread: thread.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(createThread: thread.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didDeleteThread thread: DiscordChannel) {
         log.debug("Got thread delete: \(thread.id)")
-        receiver.on(deleteThread: thread.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(deleteThread: thread.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didUpdateThread thread: DiscordChannel) {
         log.debug("Got thread update: \(thread.id)")
-        receiver.on(updateThread: thread.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(updateThread: thread.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didCreateGuild guild: DiscordGuild) {
         log.debug("Created guild")
-        receiver.on(createGuild: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(createGuild: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didDeleteGuild guild: DiscordGuild) {
         log.debug("Deleted guild")
-        receiver.on(deleteGuild: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(deleteGuild: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didUpdateGuild guild: DiscordGuild) {
         log.debug("Updated guild")
-        receiver.on(updateGuild: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(updateGuild: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didAddGuildMember member: DiscordGuildMember) {
@@ -97,7 +119,9 @@ public class DiscordClientManager: DiscordClientDelegate {
             log.error("Guild member \(member.user.username ?? "?") has no guild id")
             return
         }
-        receiver.on(addGuildMember: member.usingMessageIO(in: guildId), sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(addGuildMember: member.usingMessageIO(in: guildId), sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didRemoveGuildMember member: DiscordGuildMember) {
@@ -106,7 +130,9 @@ public class DiscordClientManager: DiscordClientDelegate {
             log.error("Guild member \(member.user.username ?? "?") has no guild id")
             return
         }
-        receiver.on(removeGuildMember: member.usingMessageIO(in: guildId), sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(removeGuildMember: member.usingMessageIO(in: guildId), sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didUpdateGuildMember member: DiscordGuildMember) {
@@ -115,86 +141,116 @@ public class DiscordClientManager: DiscordClientDelegate {
             log.error("Guild member \(member.user.username ?? "?") has no guild id")
             return
         }
-        receiver.on(updateGuildMember: member.usingMessageIO(in: guildId), sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(updateGuildMember: member.usingMessageIO(in: guildId), sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didUpdateMessage message: DiscordMessage) {
         log.debug("Got message update")
         let sink = overlaySink(with: discordClient)
-        receiver.on(updateMessage: message.usingMessageIO(with: sink), sink: sink)
+        Task {
+            await receiver.on(updateMessage: message.usingMessageIO(with: sink), sink: sink)
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didCreateMessage message: DiscordMessage) {
         log.debug("Got message")
         let sink = overlaySink(with: discordClient)
-        receiver.on(createMessage: message.usingMessageIO(with: sink), sink: sink)
+        Task {
+            await receiver.on(createMessage: message.usingMessageIO(with: sink), sink: sink)
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didAddReaction reaction: DiscordEmoji, toMessage messageID: Discord.MessageID, onChannel channel: DiscordChannel, user userID: Discord.UserID) {
         log.debug("Did add reaction")
-        receiver.on(addReaction: reaction.usingMessageIO, to: messageID.usingMessageIO, on: channel.id.usingMessageIO, by: userID.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(addReaction: reaction.usingMessageIO, to: messageID.usingMessageIO, on: channel.id.usingMessageIO, by: userID.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didRemoveReaction reaction: DiscordEmoji, fromMessage messageID: Discord.MessageID, onChannel channel: DiscordChannel, user userID: Discord.UserID) {
         log.debug("Did remove reaction")
-        receiver.on(removeReaction: reaction.usingMessageIO, from: messageID.usingMessageIO, on: channel.id.usingMessageIO, by: userID.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(removeReaction: reaction.usingMessageIO, from: messageID.usingMessageIO, on: channel.id.usingMessageIO, by: userID.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didRemoveAllReactionsFrom messageID: Discord.MessageID, onChannel channel: DiscordChannel) {
         log.debug("Did remove all reactions")
-        receiver.on(removeAllReactionsFrom: messageID.usingMessageIO, on: channel.id.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(removeAllReactionsFrom: messageID.usingMessageIO, on: channel.id.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didCreateRole role: DiscordRole, onGuild guild: DiscordGuild) {
         log.debug("Got role create: \(role.name) on guild \(guild.name ?? "?")")
-        receiver.on(createRole: role.usingMessageIO, on: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(createRole: role.usingMessageIO, on: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didDeleteRole role: DiscordRole, onGuild guild: DiscordGuild) {
         log.debug("Got role delete: \(role.name) on guild \(guild.name ?? "?")")
-        receiver.on(deleteRole: role.usingMessageIO, from: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(deleteRole: role.usingMessageIO, from: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didUpdateRole role: DiscordRole, onGuild guild: DiscordGuild) {
         log.debug("Got role update: \(role.name) on guild \(guild.name ?? "?")")
-        receiver.on(updateRole: role.usingMessageIO, on: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(updateRole: role.usingMessageIO, on: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didReceivePresenceUpdate presence: DiscordPresence) {
         log.debug("Got presence update")
-        receiver.on(receivePresenceUpdate: presence.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(receivePresenceUpdate: presence.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didReceiveReady ready: DiscordReadyEvent) {
         log.debug("Received ready")
         // TODO: Add a strongly-typed ReadyEvent in D2MessageIO
-        receiver.on(receiveReady: [
-            "gatewayVersion": ready.gatewayVersion as Any,
-            "shard": ready.shard as Any
-        ], sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(receiveReady: [
+                "gatewayVersion": ready.gatewayVersion as Any,
+                "shard": ready.shard as Any
+            ], sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didCreateInteraction interaction: DiscordInteraction) {
         log.debug("Created interaction")
         let sink = overlaySink(with: discordClient)
-        receiver.on(createInteraction: interaction.usingMessageIO(with: sink), sink: sink)
+        Task {
+            await receiver.on(createInteraction: interaction.usingMessageIO(with: sink), sink: sink)
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didReceiveVoiceStateUpdate voiceState: DiscordVoiceState) {
         log.debug("Got voice state update")
-        receiver.on(receiveVoiceStateUpdate: voiceState.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(receiveVoiceStateUpdate: voiceState.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didHandleGuildMemberChunk chunk: [DiscordGuildMember], forGuild guild: DiscordGuild) {
         log.debug("Handling guild member chunk")
         let newChunk = Dictionary(uniqueKeysWithValues: chunk.map { ($0.id.usingMessageIO, $0.usingMessageIO(in: guild.id.usingMessageIO)) })
-        receiver.on(handleGuildMemberChunk: newChunk, for: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(handleGuildMemberChunk: newChunk, for: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     public func client(_ discordClient: DiscordClient, didUpdateEmojis emojis: [DiscordEmoji], onGuild guild: DiscordGuild) {
         log.debug("Got updated emojis")
         let newEmojis = Dictionary(uniqueKeysWithValues: emojis.compactMap { e in e.id.map { ($0.usingMessageIO, e.usingMessageIO) } })
-        receiver.on(updateEmojis: newEmojis, on: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        Task {
+            await receiver.on(updateEmojis: newEmojis, on: guild.usingMessageIO, sink: overlaySink(with: discordClient))
+        }
     }
 
     private func overlaySink(with discordClient: DiscordClient) -> Sink {

--- a/Sources/D2IRCIO/IRCClientManager.swift
+++ b/Sources/D2IRCIO/IRCClientManager.swift
@@ -86,7 +86,9 @@ public class IRCClientManager: IRCClientDelegate {
             channelId: ID(channelName.stringValue, clientName: name)
         )
 
-        receiver.on(createMessage: m, sink: overlaySink(with: ircClient))
+        Task {
+            await receiver.on(createMessage: m, sink: overlaySink(with: ircClient))
+        }
     }
 
     private func overlaySink(with ircClient: IRCClient) -> Sink {

--- a/Sources/D2MessageIO/Receiver.swift
+++ b/Sources/D2MessageIO/Receiver.swift
@@ -2,117 +2,117 @@ import Utils
 
 /// A handler for events from the message backend.
 public protocol Receiver {
-    func on(connect connected: Bool, sink: any Sink)
+    func on(connect connected: Bool, sink: any Sink) async
 
-    func on(disconnectWithReason reason: String, sink: any Sink)
+    func on(disconnectWithReason reason: String, sink: any Sink) async
 
-    func on(createChannel channel: Channel, sink: any Sink)
+    func on(createChannel channel: Channel, sink: any Sink) async
 
-    func on(deleteChannel channel: Channel, sink: any Sink)
+    func on(deleteChannel channel: Channel, sink: any Sink) async
 
-    func on(updateChannel channel: Channel, sink: any Sink)
+    func on(updateChannel channel: Channel, sink: any Sink) async
 
-    func on(createThread thread: Channel, sink: any Sink)
+    func on(createThread thread: Channel, sink: any Sink) async
 
-    func on(deleteThread thread: Channel, sink: any Sink)
+    func on(deleteThread thread: Channel, sink: any Sink) async
 
-    func on(updateThread thread: Channel, sink: any Sink)
+    func on(updateThread thread: Channel, sink: any Sink) async
 
-    func on(createGuild guild: Guild, sink: any Sink)
+    func on(createGuild guild: Guild, sink: any Sink) async
 
-    func on(deleteGuild guild: Guild, sink: any Sink)
+    func on(deleteGuild guild: Guild, sink: any Sink) async
 
-    func on(updateGuild guild: Guild, sink: any Sink)
+    func on(updateGuild guild: Guild, sink: any Sink) async
 
-    func on(addGuildMember member: Guild.Member, sink: any Sink)
+    func on(addGuildMember member: Guild.Member, sink: any Sink) async
 
-    func on(removeGuildMember member: Guild.Member, sink: any Sink)
+    func on(removeGuildMember member: Guild.Member, sink: any Sink) async
 
-    func on(updateGuildMember member: Guild.Member, sink: any Sink)
+    func on(updateGuildMember member: Guild.Member, sink: any Sink) async
 
-    func on(updateMessage message: Message, sink: any Sink)
+    func on(updateMessage message: Message, sink: any Sink) async
 
-    func on(createMessage message: Message, sink: any Sink)
+    func on(createMessage message: Message, sink: any Sink) async
 
-    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink)
+    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) async
 
-    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink)
+    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) async
 
-    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, sink: any Sink)
+    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, sink: any Sink) async
 
-    func on(createRole role: Role, on guild: Guild, sink: any Sink)
+    func on(createRole role: Role, on guild: Guild, sink: any Sink) async
 
-    func on(deleteRole role: Role, from guild: Guild, sink: any Sink)
+    func on(deleteRole role: Role, from guild: Guild, sink: any Sink) async
 
-    func on(updateRole role: Role, on guild: Guild, sink: any Sink)
+    func on(updateRole role: Role, on guild: Guild, sink: any Sink) async
 
-    func on(receivePresenceUpdate presence: Presence, sink: any Sink)
+    func on(receivePresenceUpdate presence: Presence, sink: any Sink) async
 
-    func on(createInteraction interaction: Interaction, sink: any Sink)
+    func on(createInteraction interaction: Interaction, sink: any Sink) async
 
-    func on(receiveReady data: [String: Any], sink: any Sink)
+    func on(receiveReady data: [String: Any], sink: any Sink) async
 
-    func on(receiveVoiceStateUpdate state: VoiceState, sink: any Sink)
+    func on(receiveVoiceStateUpdate state: VoiceState, sink: any Sink) async
 
-    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, sink: any Sink)
+    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, sink: any Sink) async
 
-    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, sink: any Sink)
+    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, sink: any Sink) async
 }
 
 public extension Receiver {
-    func on(connect connected: Bool, sink: any Sink) {}
+    func on(connect connected: Bool, sink: any Sink) async {}
 
-    func on(disconnectWithReason reason: String, sink: any Sink) {}
+    func on(disconnectWithReason reason: String, sink: any Sink) async {}
 
-    func on(createChannel channel: Channel, sink: any Sink) {}
+    func on(createChannel channel: Channel, sink: any Sink) async {}
 
-    func on(deleteChannel channel: Channel, sink: any Sink) {}
+    func on(deleteChannel channel: Channel, sink: any Sink) async {}
 
-    func on(updateChannel channel: Channel, sink: any Sink) {}
+    func on(updateChannel channel: Channel, sink: any Sink) async {}
 
-    func on(createThread thread: Channel, sink: any Sink) {}
+    func on(createThread thread: Channel, sink: any Sink) async {}
 
-    func on(deleteThread thread: Channel, sink: any Sink) {}
+    func on(deleteThread thread: Channel, sink: any Sink) async {}
 
-    func on(updateThread thread: Channel, sink: any Sink) {}
+    func on(updateThread thread: Channel, sink: any Sink) async {}
 
-    func on(createGuild guild: Guild, sink: any Sink) {}
+    func on(createGuild guild: Guild, sink: any Sink) async {}
 
-    func on(deleteGuild guild: Guild, sink: any Sink) {}
+    func on(deleteGuild guild: Guild, sink: any Sink) async {}
 
-    func on(updateGuild guild: Guild, sink: any Sink) {}
+    func on(updateGuild guild: Guild, sink: any Sink) async {}
 
-    func on(addGuildMember member: Guild.Member, sink: any Sink) {}
+    func on(addGuildMember member: Guild.Member, sink: any Sink) async {}
 
-    func on(removeGuildMember member: Guild.Member, sink: any Sink) {}
+    func on(removeGuildMember member: Guild.Member, sink: any Sink) async {}
 
-    func on(updateGuildMember member: Guild.Member, sink: any Sink) {}
+    func on(updateGuildMember member: Guild.Member, sink: any Sink) async {}
 
-    func on(updateMessage message: Message, sink: any Sink) {}
+    func on(updateMessage message: Message, sink: any Sink) async {}
 
-    func on(createMessage message: Message, sink: any Sink) {}
+    func on(createMessage message: Message, sink: any Sink) async {}
 
-    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {}
+    func on(addReaction reaction: Emoji, to messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) async {}
 
-    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) {}
+    func on(removeReaction reaction: Emoji, from messageId: MessageID, on channelId: ChannelID, by userId: UserID, sink: any Sink) async {}
 
-    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, sink: any Sink) {}
+    func on(removeAllReactionsFrom message: MessageID, on channelId: ChannelID, sink: any Sink) async {}
 
-    func on(createRole role: Role, on guild: Guild, sink: any Sink) {}
+    func on(createRole role: Role, on guild: Guild, sink: any Sink) async {}
 
-    func on(deleteRole role: Role, from guild: Guild, sink: any Sink) {}
+    func on(deleteRole role: Role, from guild: Guild, sink: any Sink) async {}
 
-    func on(updateRole role: Role, on guild: Guild, sink: any Sink) {}
+    func on(updateRole role: Role, on guild: Guild, sink: any Sink) async {}
 
-    func on(receivePresenceUpdate presence: Presence, sink: any Sink) {}
+    func on(receivePresenceUpdate presence: Presence, sink: any Sink) async {}
 
-    func on(createInteraction interaction: Interaction, sink: any Sink) {}
+    func on(createInteraction interaction: Interaction, sink: any Sink) async {}
 
-    func on(receiveReady data: [String: Any], sink: any Sink) {}
+    func on(receiveReady data: [String: Any], sink: any Sink) async {}
 
-    func on(receiveVoiceStateUpdate state: VoiceState, sink: any Sink) {}
+    func on(receiveVoiceStateUpdate state: VoiceState, sink: any Sink) async {}
 
-    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, sink: any Sink) {}
+    func on(handleGuildMemberChunk chunk: [UserID: Guild.Member], for guild: Guild, sink: any Sink) async {}
 
-    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, sink: any Sink) {}
+    func on(updateEmojis emojis: [EmojiID: Emoji], on guild: Guild, sink: any Sink) async {}
 }


### PR DESCRIPTION
This moves the spawning of tasks into the concrete implementation, in this case `DiscordClientManager`. Once `swift-discord` supports async/await natively (https://github.com/fwcd/swift-discord/issues/22) we could remove those tasks too.