### PR TITLE
Migrate to `swift-static-map`

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "966d3f0addad190de706ca3584e86378c30cc320d3604acc196ebd0e89ff8946",
+  "originHash" : "298a5f5d129e175f5d056f8d810c5bbdc2cac3cc3a064f8c7625959d26b84966",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -338,8 +338,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/fwcd/swift-static-map.git",
       "state" : {
-        "revision" : "9342d1ed10bbdb797409fc9f54da282c54233ae6",
-        "version" : "0.4.0"
+        "revision" : "e0020edc8d8b812cd5b90e793c1aef0244f2c6b3",
+        "version" : "0.5.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7e180e984ab94111becbae8597d02417d8b91497e3e8b33163001d246c9f4667",
+  "originHash" : "966d3f0addad190de706ca3584e86378c30cc320d3604acc196ebd0e89ff8946",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -338,8 +338,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/fwcd/swift-static-map.git",
       "state" : {
-        "revision" : "7b72414ea8422c23d15044fd1bd1a8419fd8e487",
-        "version" : "0.3.0"
+        "revision" : "9342d1ed10bbdb797409fc9f54da282c54233ae6",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2683a7b1651a77cb26316dbb6fb8400629bc077d50065e7969b8371df528f918",
+  "originHash" : "6cbca0510b4833ba7b7d30a16c43834e52128d1df25cb0ea67ad857ff1925cdc",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -338,8 +338,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/fwcd/swift-static-map.git",
       "state" : {
-        "revision" : "5db8bd3ca59b06e73bcee854d8ee3507c0c27ca7",
-        "version" : "0.1.0"
+        "revision" : "159a3c99aae7c1721d74a3520bb4ecc92f21ede1",
+        "version" : "0.2.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6cbca0510b4833ba7b7d30a16c43834e52128d1df25cb0ea67ad857ff1925cdc",
+  "originHash" : "7e180e984ab94111becbae8597d02417d8b91497e3e8b33163001d246c9f4667",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -194,8 +194,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/fwcd/swift-graphics.git",
       "state" : {
-        "revision" : "bb63a812bc5410af7f07cdc636371d55cc3e2aeb",
-        "version" : "4.0.0"
+        "revision" : "d761f1856b3e6f9472d4d06db9bce9106f0650ca",
+        "version" : "4.0.3"
       }
     },
     {
@@ -338,8 +338,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/fwcd/swift-static-map.git",
       "state" : {
-        "revision" : "159a3c99aae7c1721d74a3520bb4ecc92f21ede1",
-        "version" : "0.2.0"
+        "revision" : "7b72414ea8422c23d15044fd1bd1a8419fd8e487",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/fwcd/swift-gif.git", from: "4.0.0"),
         .package(url: "https://github.com/fwcd/swift-mensa.git", from: "0.1.10"),
         .package(url: "https://github.com/fwcd/swift-music-theory.git", from: "0.1.0"),
-        .package(url: "https://github.com/fwcd/swift-static-map.git", from: "0.4.0"),
+        .package(url: "https://github.com/fwcd/swift-static-map.git", from: "0.5.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.59.0"),
         .package(url: "https://github.com/Kitura/BlueSocket.git", .upToNextMinor(from: "2.0.4")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.3"),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/fwcd/swift-gif.git", from: "4.0.0"),
         .package(url: "https://github.com/fwcd/swift-mensa.git", from: "0.1.10"),
         .package(url: "https://github.com/fwcd/swift-music-theory.git", from: "0.1.0"),
-        .package(url: "https://github.com/fwcd/swift-static-map.git", from: "0.1.0"),
+        .package(url: "https://github.com/fwcd/swift-static-map.git", from: "0.2.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.59.0"),
         .package(url: "https://github.com/Kitura/BlueSocket.git", .upToNextMinor(from: "2.0.4")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.3"),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/fwcd/swift-gif.git", from: "4.0.0"),
         .package(url: "https://github.com/fwcd/swift-mensa.git", from: "0.1.10"),
         .package(url: "https://github.com/fwcd/swift-music-theory.git", from: "0.1.0"),
-        .package(url: "https://github.com/fwcd/swift-static-map.git", from: "0.2.0"),
+        .package(url: "https://github.com/fwcd/swift-static-map.git", from: "0.3.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.59.0"),
         .package(url: "https://github.com/Kitura/BlueSocket.git", .upToNextMinor(from: "2.0.4")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.3"),

--- a/Package.swift
+++ b/Package.swift
@@ -24,7 +24,7 @@ let package = Package(
         .package(url: "https://github.com/fwcd/swift-gif.git", from: "4.0.0"),
         .package(url: "https://github.com/fwcd/swift-mensa.git", from: "0.1.10"),
         .package(url: "https://github.com/fwcd/swift-music-theory.git", from: "0.1.0"),
-        .package(url: "https://github.com/fwcd/swift-static-map.git", from: "0.3.0"),
+        .package(url: "https://github.com/fwcd/swift-static-map.git", from: "0.4.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.59.0"),
         .package(url: "https://github.com/Kitura/BlueSocket.git", .upToNextMinor(from: "2.0.4")),
         .package(url: "https://github.com/swift-server/swift-backtrace.git", from: "1.3.3"),

--- a/Sources/D2Commands/CAU/UnivIS/CampusCommand.swift
+++ b/Sources/D2Commands/CAU/UnivIS/CampusCommand.swift
@@ -42,9 +42,8 @@ public class CampusCommand: StringCommand {
             let coords = try await geocoder.geocode(location: address)
 
             let mapData = try await StaticMap(
-                center: coords
-                // TODO: Add pins once we add support for annotations
-                // pins: [.init(coords: coords)]
+                center: coords,
+                annotations: [.pin(coords: coords)]
             ).render().pngEncoded()
 
             await output.append(.compound([

--- a/Sources/D2Commands/CAU/UnivIS/CampusCommand.swift
+++ b/Sources/D2Commands/CAU/UnivIS/CampusCommand.swift
@@ -5,6 +5,7 @@ import Foundation
 import FoundationNetworking
 #endif
 import Logging
+import StaticMap
 import Utils
 import D2NetAPIs
 
@@ -40,10 +41,11 @@ public class CampusCommand: StringCommand {
             let address = self.format(rawAddress: rawAddress)
             let coords = try await geocoder.geocode(location: address)
 
-            let mapData = try await MapQuestStaticMap(
-                center: coords,
-                pins: [.init(coords: coords)]
-            ).download()
+            let mapData = try await StaticMap(
+                center: coords
+                // TODO: Add pins once we add support for annotations
+                // pins: [.init(coords: coords)]
+            ).render().pngEncoded()
 
             await output.append(.compound([
                 .files([Message.FileUpload(data: mapData, filename: "campus.jpg", mimeType: "image/jpeg")]),

--- a/Sources/D2Commands/CAU/UnivIS/CampusCommand.swift
+++ b/Sources/D2Commands/CAU/UnivIS/CampusCommand.swift
@@ -47,7 +47,7 @@ public class CampusCommand: StringCommand {
             ).render().pngEncoded()
 
             await output.append(.compound([
-                .files([Message.FileUpload(data: mapData, filename: "campus.jpg", mimeType: "image/jpeg")]),
+                .files([Message.FileUpload(data: mapData, filename: "campus.png", mimeType: "image/png")]),
                 .embed(Embed(
                     title: address,
                     url: self.googleMapsURLFor(address: address)

--- a/Sources/D2Commands/CAU/UnivIS/CampusCommand.swift
+++ b/Sources/D2Commands/CAU/UnivIS/CampusCommand.swift
@@ -41,13 +41,8 @@ public class CampusCommand: StringCommand {
             let address = self.format(rawAddress: rawAddress)
             let coords = try await geocoder.geocode(location: address)
 
-            let mapData = try await StaticMap(
-                center: coords,
-                annotations: [.pin(coords: coords)]
-            ).render().pngEncoded()
-
             await output.append(.compound([
-                .files([Message.FileUpload(data: mapData, filename: "campus.png", mimeType: "image/png")]),
+                .geoCoordinates(coords),
                 .embed(Embed(
                     title: address,
                     url: self.googleMapsURLFor(address: address)

--- a/Sources/D2Commands/Misc/GeoIPCommand.swift
+++ b/Sources/D2Commands/Misc/GeoIPCommand.swift
@@ -26,15 +26,8 @@ public class GeoIPCommand: StringCommand {
                 return
             }
 
-            let mapData = try await StaticMap(
-                zoom: 2,
-                center: coords,
-                annotations: [.pin(coords: coords)]
-            ).render().pngEncoded()
-            let mapFileUpload = Message.FileUpload(data: mapData, filename: "map.png", mimeType: "image/png")
-
             await output.append(.compound([
-                .files([mapFileUpload].compactMap { $0 }),
+                .geoCoordinates(coords),
                 .embed(Embed(
                     title: "GeoIP info for `\(data.ip)`",
                     fields: [

--- a/Sources/D2Commands/Misc/GeoIPCommand.swift
+++ b/Sources/D2Commands/Misc/GeoIPCommand.swift
@@ -1,5 +1,6 @@
 import D2MessageIO
 import D2NetAPIs
+import StaticMap
 import Utils
 
 public class GeoIPCommand: StringCommand {
@@ -25,7 +26,11 @@ public class GeoIPCommand: StringCommand {
                 return
             }
 
-            let mapData = try await MapQuestStaticMap(center: coords, pins: [.init(coords: coords)], zoom: 2).download()
+            let mapData = try await StaticMap(
+                zoom: 2,
+                center: coords,
+                annotations: [.pin(coords: coords)]
+            ).render().pngEncoded()
             let mapFileUpload = Message.FileUpload(data: mapData, filename: "map.jpg", mimeType: "image/jpeg")
 
             await output.append(.compound([

--- a/Sources/D2Commands/Misc/GeoIPCommand.swift
+++ b/Sources/D2Commands/Misc/GeoIPCommand.swift
@@ -31,7 +31,7 @@ public class GeoIPCommand: StringCommand {
                 center: coords,
                 annotations: [.pin(coords: coords)]
             ).render().pngEncoded()
-            let mapFileUpload = Message.FileUpload(data: mapData, filename: "map.jpg", mimeType: "image/jpeg")
+            let mapFileUpload = Message.FileUpload(data: mapData, filename: "map.png", mimeType: "image/png")
 
             await output.append(.compound([
                 .files([mapFileUpload].compactMap { $0 }),

--- a/Sources/D2Commands/Misc/TierVehiclesCommand.swift
+++ b/Sources/D2Commands/Misc/TierVehiclesCommand.swift
@@ -26,6 +26,12 @@ public class TierVehiclesCommand: Command {
 
         do {
             let vehicles = try await TierVehiclesQuery(coords: coords, radius: radius).perform().data
+
+            guard !vehicles.isEmpty else {
+                await output.append(errorText: "No vehicles found")
+                return
+            }
+
             let activeColor = Color(rgb: 0x498f00)
             let inactiveColor = Color.gray
             let map = StaticMap(

--- a/Sources/D2Commands/Misc/TierVehiclesCommand.swift
+++ b/Sources/D2Commands/Misc/TierVehiclesCommand.swift
@@ -39,7 +39,7 @@ public class TierVehiclesCommand: Command {
             )
             let mapImageData = try await map.render().pngEncoded()
             await output.append(.compound([
-                .files([Message.FileUpload(data: mapImageData, filename: "vehicles.jpg", mimeType: "image/jpeg")]),
+                .files([Message.FileUpload(data: mapImageData, filename: "vehicles.png", mimeType: "image/png")]),
                 .embed(Embed(
                     title: ":scooter: Tier Vehicles in a Radius of \(radius)m around \(coords.latitude), \(coords.longitude)",
                     fields: vehicles

--- a/Sources/D2Commands/Misc/TierVehiclesCommand.swift
+++ b/Sources/D2Commands/Misc/TierVehiclesCommand.swift
@@ -26,8 +26,8 @@ public class TierVehiclesCommand: Command {
 
         do {
             let vehicles = try await TierVehiclesQuery(coords: coords, radius: radius).perform().data
-            let activeColor = Color(rgb: 0xdcffb8)
-            let inactiveColor = Color(rgb: 0xffe7b8)
+            let activeColor = Color(rgb: 0x498f00)
+            let inactiveColor = Color.gray
             let map = StaticMap(
                 annotations: vehicles
                     .enumerated()

--- a/Sources/D2Commands/Misc/TierVehiclesCommand.swift
+++ b/Sources/D2Commands/Misc/TierVehiclesCommand.swift
@@ -1,5 +1,7 @@
 import D2MessageIO
 import D2NetAPIs
+import Graphics
+import StaticMap
 import Utils
 
 public class TierVehiclesCommand: Command {
@@ -24,21 +26,18 @@ public class TierVehiclesCommand: Command {
 
         do {
             let vehicles = try await TierVehiclesQuery(coords: coords, radius: radius).perform().data
-            let map = try MapQuestStaticMap(
-                pins: vehicles
+            let activeColor = Color(rgb: 0xdcffb8)
+            let inactiveColor = Color(rgb: 0xffe7b8)
+            let map = StaticMap(
+                annotations: vehicles
                     .enumerated()
-                    .map { (i, vehicle) in .init(
-                        coords: vehicle.attributes.coords,
-                        marker: [
-                            "flag", // type
-                            "sm", // size
-                            "000000", // bg color
-                            vehicle.attributes.state == "ACTIVE" ? "dcffb8" : "ffe7b8", // fg color
-                            "\(i + 1)\(vehicle.attributes.batteryLevel.map { ":\($0)%25" } ?? "")" // text
-                        ].joined(separator: "-")
-                    ) }
+                    .map { (i, vehicle) in
+                        .pin(coords: vehicle.attributes.coords)
+                            .color(vehicle.attributes.state == "ACTIVE" ? activeColor : inactiveColor)
+                            .label("\(i + 1)\(vehicle.attributes.batteryLevel.map { ":\($0)%25" } ?? "")")
+                    }
             )
-            let mapImageData = try await map.download()
+            let mapImageData = try await map.render().pngEncoded()
             await output.append(.compound([
                 .files([Message.FileUpload(data: mapImageData, filename: "vehicles.jpg", mimeType: "image/jpeg")]),
                 .embed(Embed(

--- a/Sources/D2Commands/Output/MessageWriter.swift
+++ b/Sources/D2Commands/Output/MessageWriter.swift
@@ -1,4 +1,5 @@
 import Logging
+import StaticMap
 import D2MessageIO
 import Utils
 
@@ -47,8 +48,15 @@ public struct MessageWriter {
                     """)
             case let .embed(embed):
                 return Message(embed: embed)
-            case let .geoCoordinates(geo):
-                return Message(content: "Latitude: \(geo.latitude), Longitude: \(geo.longitude)")
+            case let .geoCoordinates(coords):
+                let mapImage = try await StaticMap(
+                    center: coords,
+                    annotations: [.pin(coords: coords)]
+                ).render()
+                return try await write(value: .compound([
+                    .image(mapImage),
+                    .text("\(coords)"),
+                ]))
             case let .ndArrays(ndArrays):
                 if ndArrays.contains(where: { !$0.isScalar }) {
                     let image = try await latexRenderer.renderImage(from: latexOf(ndArrays: ndArrays))


### PR DESCRIPTION
### Fixes #166 

This migrates commands generating static maps to [`swift-static-map`](https://github.com/fwcd/swift-static-map), a new package that stitches static maps directly from OpenStreetMap tiles.

### To do

- [x] Migrate `CampusCommand`
- [x] Migrate `GeoIPCommand`
- [x] Migrate `TierVehiclesCommand`