### PR TITLE
Migrate to Discord API v10

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c79414dbbbaf6bd872b3121ebd7c17b74f9954eca2517ccc84a93555a5039711",
+  "originHash" : "9990b4979d5f1ffd728d0e5c2ddb5f8f39df4cfd47ed6db5500a970eaf4f1507",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -167,7 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/fwcd/swift-discord.git",
       "state" : {
-        "revision" : "b7fcda889f28d74425c35262ea9311092aacb2d4"
+        "revision" : "2f8b9079488b0d8f78377a8d7ac6d6669efcc381",
+        "version" : "13.0.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c6ae4c140de386ef7bd40fa61d968c22c06b4f89a844cb2bc394fb2bde4599c6",
+  "originHash" : "c79414dbbbaf6bd872b3121ebd7c17b74f9954eca2517ccc84a93555a5039711",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -167,8 +167,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/fwcd/swift-discord.git",
       "state" : {
-        "revision" : "fb02932ae2984cb12286a993ad518a1df54d02b1",
-        "version" : "12.0.2"
+        "revision" : "b7fcda889f28d74425c35262ea9311092aacb2d4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -11,8 +11,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        // TODO: Use released version once https://github.com/fwcd/swift-discord/pull/20 is merged
-        .package(url: "https://github.com/fwcd/swift-discord.git", revision: "b7fcda889f28d74425c35262ea9311092aacb2d4"),
+        .package(url: "https://github.com/fwcd/swift-discord.git", from: "13.0.0"),
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.4.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.2"),

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/fwcd/swift-discord.git", .upToNextMinor(from: "12.0.2")),
+        // TODO: Use released version once https://github.com/fwcd/swift-discord/pull/20 is merged
+        .package(url: "https://github.com/fwcd/swift-discord.git", revision: "b7fcda889f28d74425c35262ea9311092aacb2d4"),
         .package(url: "https://github.com/attaswift/BigInt.git", from: "5.3.0"),
         .package(url: "https://github.com/scinfu/SwiftSoup.git", from: "2.4.3"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.4.2"),

--- a/Sources/D2DiscordIO/DiscordMessageConverter.swift
+++ b/Sources/D2DiscordIO/DiscordMessageConverter.swift
@@ -5,10 +5,9 @@ import Discord
 
 extension Message: DiscordAPIConvertible {
     public var usingDiscordAPI: DiscordMessage {
-        let embed: Embed? = embeds.first
         return DiscordMessage(
             content: content,
-            embed: embed?.usingDiscordAPI,
+            embeds: embeds.usingDiscordAPI,
             files: files.usingDiscordAPI,
             tts: tts,
             components: components.usingDiscordAPI
@@ -20,7 +19,7 @@ extension Message.Edit: DiscordAPIConvertible {
     public var usingDiscordAPI: DiscordMessage.Edit {
         return DiscordMessage.Edit(
             content: content,
-            embed: embed?.usingDiscordAPI,
+            embeds: embeds?.usingDiscordAPI,
             components: components?.usingDiscordAPI
         )
     }

--- a/Sources/D2MessageIO/Structures/Message.swift
+++ b/Sources/D2MessageIO/Structures/Message.swift
@@ -109,16 +109,16 @@ public struct Message: ExpressibleByStringLiteral {
 
     public struct Edit {
         public var content: String?
-        public var embed: Embed?
+        public var embeds: [Embed]?
         public var components: [Component]?
 
         public init(
             content: String? = nil,
-            embed: Embed? = nil,
+            embeds: [Embed]? = nil,
             components: [Component]? = nil
         ) {
             self.content = content
-            self.embed = embed
+            self.embeds = embeds
             self.components = components
         }
     }


### PR DESCRIPTION
Sibling PR to https://github.com/fwcd/swift-discord/pull/20, which integrates the new version of `swift-discord`.